### PR TITLE
Fix missing header causing compilation issues with newer versions of Boost

### DIFF
--- a/SOLVER/src/shared/utilities/bstring.hpp
+++ b/SOLVER/src/shared/utilities/bstring.hpp
@@ -15,6 +15,7 @@
 #pragma clang diagnostic ignored "-Weverything"
 #include <boost/lexical_cast.hpp>
 #include <boost/algorithm/string.hpp>
+#include <boost/type_index.hpp>
 #pragma clang diagnostic pop
 
 #include <map>


### PR DESCRIPTION
Hi,

as discussed in https://github.com/AxiSEMunity/AxiSEM3D/issues/53 a missing include is causing compilation errors with newer versions of Boost. With this fix, compilation against Boost 1.85.0 is successful. I also tested if the change causes any issues with older versions of Boost, but at least with Boost 1.79.0 compilation also works. Anything lower than that I can't test since earlier toolchains of Easybuild have an incompatible version of Eigen.