### PR TITLE
CMake: do not require 4.0

### DIFF
--- a/SOLVER/CMakeLists.txt
+++ b/SOLVER/CMakeLists.txt
@@ -87,7 +87,7 @@ setDefault(USE_DOUBLE                  OFF)
 
 ################# cmake setup #################
 # project
-cmake_minimum_required(VERSION 4.0)
+cmake_minimum_required(VERSION 3.28)
 project(AxiSEM3D)
 
 # use "Release" as the default build type


### PR DESCRIPTION
I know the conda environment installs cmake 4.2, but for users without conda/mamba, it is nice not to require the most recent version. Ubuntu 24.04 ships with cmake 3.28, which seems like a good baseline.