### PR TITLE
add readthedocs configuration

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,24 @@
+# .readthedocs.yml
+# Read the Docs configuration file
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+
+# Required
+version: 2
+
+build:
+  os: "ubuntu-22.04"
+  tools:
+      python: "mambaforge-4.10"
+
+# Build documentation in the root directory with Sphinx
+sphinx:
+  configuration: ./doc/sphinx/source/conf.py
+  fail_on_warning: false
+
+# Optionally build your docs in additional formats such as PDF and ePub
+formats:
+  - htmlzip
+  - pdf
+
+conda:
+  environment: ./doc/sphinx/environment.yml

--- a/doc/sphinx/environment.yml
+++ b/doc/sphinx/environment.yml
@@ -1,0 +1,15 @@
+name: axisem3d-sphinx
+channels:
+  - conda-forge
+  - defaults
+dependencies:
+  - myst-parser
+  - sphinx-book-theme
+  - sphinx-tags
+  - sphinx-design
+  - sphinxcontrib-bibtex
+  - cairosvg
+  - pip>=20.1
+  - pip:
+    - sphinxcontrib-tikz
+    - sphinxcontrib-svg2pdfconverter[CairoSVG]


### PR DESCRIPTION
This is required to let readthedocs build the documentation automatically. Note that the the github hooks are still missing.

FYI @ljhwang 