### PR TITLE
Initial commit of CODE_OF_CONDUCT.md

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,53 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+In the interest of fostering an open and welcoming environment, we as contributors and project leaders pledge to
+making participation in our project and our community a harassment-free experience for everyone,
+regardless of age, body size, disability, ethnicity, gender identity and expression, level of experience, nationality, personal appearance, race, religion (or lack thereof), sexual identity and orientation, or technology choices.
+
+## Our Standards
+
+Examples of behavior that contributes to creating a positive environment include:
+
+* Using welcoming and inclusive language
+* Being respectful of differing viewpoints and experiences
+* Gracefully accepting constructive criticism
+* Focusing on what is best for the community
+* Showing empathy towards other community members
+
+Examples of unacceptable behavior by participants include:
+
+* The use of sexualized language or imagery and unwelcome sexual attention or advances
+* Trolling, insulting/derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or electronic address, without explicit permission
+* Conduct which could reasonably be considered inappropriate in a professional setting
+
+## Our Responsibilities
+
+Project leaders are responsible for clarifying the standards of acceptable behavior and are expected to take appropriate and fair corrective action in response to any instances of unacceptable behavior.
+
+Project leaders have the right and responsibility to remove, edit, or
+reject comments, commits, code, wiki edits, issues, and other contributions
+that are not aligned to this Code of Conduct, or to ban temporarily or
+permanently any contributor for other behaviors that they deem inappropriate,
+threatening, offensive, or harmful. We see all of these actions as last
+resorts. Our goal is to maintain a friendly and inclusive community where
+everyone feels welcome to participate and express themselves, but conduct by
+individuals that jeopardizes the harmony of the project will need to be
+addressed.
+
+## Scope
+
+This Code of Conduct applies both within project spaces and in public spaces when an individual is representing the project or its community. Examples of representing a project or community include using an official project e-mail address, posting via an official social media account, or acting as an appointed representative at an online or offline event. Representation of a project may be further defined and clarified by project maintainers.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported by contacting any [leader](AUTHORS.md) of the project, or CIG [leadership](https://geodynamics.org/community-cig/governance). CIG leadership will review and investigate all complaints, and will respond in a way that it deems appropriate to the circumstances. CIG leadership is obligated to maintain confidentiality with regard to the reporter of an incident, although confidentiality cannot be promised in all situations under the Title IX law of the United States. Further details of specific enforcement policies may be posted separately.
+
+Project leaders who do not follow or enforce the Code of Conduct in good faith may face temporary or permanent repercussions as determined by other members of the project's leadership.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant homepage](http://contributor-covenant.org), version 1.4, available [here](http://contributor-covenant.org/version/1/4) and draws on the Community Code of Conduct of the Computational Infrastructure for Geodynamics, available [here](https://geodynamics.org/aboutus/policies/conduct).


### PR DESCRIPTION
This is the initial commit for the code of conduct. I made only minor changes from the one used by the ASPECT project.  

Changes include:

- Substituting project "leader" or "leadership" for "maintainers."
- Changing the contact email address to a link to CIG Governance.  

I also note that the original covenant this is based on is now on v3.0:
    https://www.contributor-covenant.org/version/3/0/code_of_conduct/
