### PR TITLE
DOC: Adjust command to build documentation

### DIFF
--- a/doc/INSTALL.md
+++ b/doc/INSTALL.md
@@ -21,5 +21,5 @@ verify environment:
 
 Build:
 
-    sphinx-build -M html docs/source/ docs/build/
-    
+    cd doc/sphinx
+    make html


### PR DESCRIPTION
This PR aims to adjust the command to build the documentation, as the folder structure of the AxiSEM3D repo is different compared to the default structure created by Sphinx (https://www.sphinx-doc.org/en/master/tutorial/getting-started.html).