### PR TITLE
DOC: Fix equation for self-gravitation

### DIFF
--- a/doc/sphinx/source/overview/capabilities.md
+++ b/doc/sphinx/source/overview/capabilities.md
@@ -79,7 +79,9 @@ how computationally expensive considering it can be. This comes about
 because the perturbations to the Poisson equation, which describes the
 Newtonian gravitational potential *ϕ* in terms of the mass density *ρ*:
 
-∇<sup>2</sup>*ϕ* = 4*π**G**ρ*
+```{math}
+   \nabla^{2}\phi = 4\pi G\rho
+```
 
 are felt everywhere instantaneously. Furthermore, there exists a
 coupling such that feedback from wave propagation affects the local
@@ -97,9 +99,9 @@ Einstein Field Equations may be significantly faster to implement, as
 the solutions are wave-like and hence inherently local. The potential
 *ϕ* is here expressed as the sum of propagating and static terms:
 
-$$\begin{equation}
--\frac{1}{c_g^{2}}\frac{\partial^{2}{\phi}}{\partial{t^{2}}} + \nabla^{2}\phi = 4\pi G\rho
-\end{equation}$$
+```{math}
+    -\frac{1}{c_g^{2}}\frac{\partial^{2}{\phi}}{\partial{t^{2}}} + \nabla^{2}\phi = 4\pi G\rho
+```
 
 where *c*<sub>*g*</sub> is the propagation speed. Physically, this speed
 is the speed of light (*c*), as this is the velocity at which


### PR DESCRIPTION
This PR tries to fix #98 and aim for a corrent display of the equation for the self-gravitation. For me, just removing the $$ does not work, but using a `` ```{math}  ```  `` block.

| old | new |
| --- | --- |
| <img width="927" height="447" alt="gravitation_eq_old" src="https://github.com/user-attachments/assets/0dff3e84-3bda-4393-a54d-db583f428ff6" /> | <img width="923" height="517" alt="gravitation_eq_new" src="https://github.com/user-attachments/assets/f9570675-9f82-491b-91ac-8c535aed05da" /> |
