### PR TITLE
Fix link to image in the README for the documentation

### DIFF
--- a/doc/README.md
+++ b/doc/README.md
@@ -12,10 +12,10 @@
 This version merges 3 different manual sources:
 
 * Git Wiki by Kuandai Leng
-* II. AxiSEM3D - Installation Guide by 
+* II. AxiSEM3D - Installation Guide by
 Benjamin Fernando, Jonathan Wolf, Kuangdai Leng, Tarje Nissen-Meyer,
 Will Eaton, Andrew Walker, Tim Craig, Jack Muir, Ceri Nunn, Maureen D. Long,
 and Piyush P. Khopkar
-* AxiSEM3D - an introduction to using the code and its applications 
+* AxiSEM3D - an introduction to using the code and its applications
 by Benjamin Fernando, Jonathan Wolf, Kuangdai Leng, Tarje Nissen-Meyer,
 Will Eaton, Andrew Walker, Tim Craig, Jack Muir, Ceri Nunn, and Maureen D. Long


### PR DESCRIPTION
This PR aims to fix the link to the image in the README for the documentation:

| old / currently | new / this PR |
| --- | --- |
| <img width="1505" height="493" alt="readme_docs_old" src="https://github.com/user-attachments/assets/7ceba820-600f-4a76-9c5e-82737832603e" /> | <img width="1517" height="581" alt="readme_docs_new" src="https://github.com/user-attachments/assets/8fbdb85f-a435-46d2-943f-11e36e73d2d7" /> |

Beside this, a typo is fixed and trailing white spaces are removed.