### PR TITLE
add assert in MPI_Isend path

### DIFF
--- a/src/preloop/se_model/SE_Model.cpp
+++ b/src/preloop/se_model/SE_Model.cpp
@@ -123,6 +123,7 @@ SE_Model::SE_Model(const ExodusMesh& exodusMesh,
   timer::gPreloopTimer.begin("Exchanging MPI buffers");
   std::vector<MPI_Request> reqSend(nCommProc, MPI_REQUEST_NULL);
   std::vector<MPI_Request> reqRecv(nCommProc, MPI_REQUEST_NULL);
+  assert(localMesh.mCommProc.size() == nCommProc);
   for (int iproc = 0; iproc < localMesh.mCommProc.size(); iproc++) {
     int commProc = localMesh.mCommProc[iproc];
     mpi::isend(commProc, bufSend[iproc], reqSend[iproc]);


### PR DESCRIPTION
This is likely not the reason for the MPI related error in #124, but it is nevertheless a good idea to check that we are using the correct number of requests.