### PR TITLE
make numdiff optional

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -280,8 +280,12 @@ add_custom_target(indent
 
 
 # Integration tests
-if(EXISTS "${PROJECT_SOURCE_DIR}/tests")
-  find_program(NUMDIFF_EXECUTABLE numdiff REQUIRED)
+find_program(NUMDIFF_EXECUTABLE numdiff QUIET)
+if(NOT NUMDIFF_EXECUTABLE)
+  message(STATUS "numdiff not found, skipping integration tests. See README.md for installation instructions.")
+endif()
+
+if(NUMDIFF_EXECUTABLE AND EXISTS "${PROJECT_SOURCE_DIR}/tests")
   file(MAKE_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/tests)
 
   message(STATUS "Searching for tests in ${PROJECT_SOURCE_DIR}/tests:")

--- a/README.md
+++ b/README.md
@@ -48,7 +48,20 @@ Check the executable:
 ./build/axisem3d --help
 ```
 
-Run integration tests:
+## Integration tests
+
+AxiSEM3D comes with a testsuite of integration tests that run specific configurations specified in ``./tests/`` and compare them to reference data. For this, the tools ``numdiff`` is needed.
+
+On x86 machines you can add it to your conda environment using
+```bash
+conda install -n axisem3d conda-forge::numdiff
+```
+but this package currently does not exist for ARM (Apple machines). You can use homebrew instead:
+```bash
+brew install numdiff
+```
+
+To run the integration tests:
 
 ```bash
 ctest --test-dir build --output-on-failure

--- a/environment.yml
+++ b/environment.yml
@@ -6,7 +6,6 @@ dependencies:
 
   # Build system
   - cmake=4.2.3
-  - numdiff
 
   # Compiler toolchain (required for mpicxx to work on macOS arm64)
   - compilers


### PR DESCRIPTION
arm-OSX conda has no numdiff, so configuration on apple silicon fails with the addition of the testsuite. Make it optional and give instructions how to install instead.