### PR TITLE
Add Stampede3 install script

### DIFF
--- a/tools/installation_scripts/README.md
+++ b/tools/installation_scripts/README.md
@@ -1,0 +1,23 @@
+# Installation Scripts
+These scripts are meant to be used to install AxiSEM3D on HPC clusters.
+
+
+## Stampede3 (TACC)
+
+To install AxiSEM3D on TACC's Stampede3, use the `build_axisem3d_stampede.sh` script.
+You will need to use scp to transfer the file onto Stampede3.
+Here is the syntax for the scp command:
+`scp path/to/build_axisem3d_stampede.sh username@stampede3.tacc.utexas.edu:path/to/destination/directory`
+
+You will need to replace `path/to/build_axisem3d_stampede.sh` with the correct path on your machine.
+
+You will need to replace `username@stampede3` with your actual TACC username.
+
+Finally, you will need to choose the destination directory you want within your environment on stampede3.
+A good choice is the $SCRATCH directory. In order to find the absolute location of the $SCRATCH directory 
+in your environment in stampede3, you can log into TACC and type: `printenv SCRATCH`.
+
+You will be prompted to log into TACC when running the `scp` command.
+Once the scp file transfer has completed, you can log into Stampede3 and run `build_axisem3d_stampede.sh` by typing: `chmod +x build_axisem3d_stampede.sh; ./build_axisem3d_stampede.sh;`
+
+This should compile AxiSEM3D on your environment on stampede3.

--- a/tools/installation_scripts/build_axisem3d_stampede3.sh
+++ b/tools/installation_scripts/build_axisem3d_stampede3.sh
@@ -1,0 +1,32 @@
+# Install conda for dependencies. Using modules does not seem to work well.
+wget https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh;
+chmod +x Miniconda3-latest-Linux-x86_64.sh;
+./Miniconda3-latest-Linux-x86_64.sh -b -p $SCRATCH/miniconda;
+
+# Add conda to PATH
+cd miniconda/bin; export PATH=$PATH:$(pwd); 
+
+# Clone AxiSEM3D
+cd $SCRATCH; git clone https://github.com/AxiSEMunity/AxiSEM3D.git; cd AxiSEM3D; conda env create --name axisem3d -f environment.yml;
+
+# eval is needed because conda init will not work in a shell script.
+eval "$(conda shell.bash hook)"; conda activate axisem3d; 
+
+# Run cmake
+rm -rf build && cmake -B build \
+  -Dcxx=mpicxx \
+  -Dhdf5=$CONDA_PREFIX \
+  -Dnetcdf=$CONDA_PREFIX \
+  -Deigen=$CONDA_PREFIX \
+  -Dboost=$CONDA_PREFIX \
+  -Dfftw=$CONDA_PREFIX \
+  -Dmetis=$CONDA_PREFIX
+
+# Compile AxiSEM3D
+cmake --build build;
+
+# Add AxiSEM3D to PATH
+cd build; export PATH=$PATH:$(pwd); 
+
+# Test installation
+axisem3d --help;


### PR DESCRIPTION
I added a README.md file to the tools/installation_scripts directory. The file currently includes detailed instructions on how to use the script to install axisem3d on stampede3. I did not write detailed instructions for the other scripts because I did not write the other scripts and I am not sure that the process to use them would be the same ( though I would guess that using scp to transfer scripts onto HPC's is very common ).