### PR TITLE
change courant number to one that works better for example 02

### DIFF
--- a/examples/02_3d_crust_S362ANI_regional/input_share/inparam.source.yaml
+++ b/examples/02_3d_crust_S362ANI_regional/input_share/inparam.source.yaml
@@ -32,7 +32,7 @@ time_axis:
     #       3) if Courant_number < 0.3 but instability still occurs,
     #          it is likely to be an issue caused by an input 3D model
     #          (e.g., mislocation near a model boundary)
-    Courant_number: 1.0
+    Courant_number: 0.6
 
     # what: time integrator
     # type: string


### PR DESCRIPTION
Running simulation with a courant number of 1.0 is unstable, 0.6 works better, so new users can run the example without changing as much.