### PR TITLE
Add option to make mesh partitioning deterministic

### DIFF
--- a/doc/sphinx/source/user/solver/y_advanced.md
+++ b/doc/sphinx/source/user/solver/y_advanced.md
@@ -21,6 +21,8 @@ mpi:
     plot_domain_decomposition: false
 ```
 
+`weight_for_load_balancing` may be `ELEMENT_POINT` (using micro-benchmark for METIS in Stage II based on element and point evaluation), `ELEMENT` (same, but ignore point evaluation cost) or `NR` (reuse the same Nr-based weights from Stage-I without timing, this produces a reproducible partition for integration tests).
+
 **developers**
 ```
 develop:

--- a/examples/template_develop/input/inparam.advanced.yaml
+++ b/examples/template_develop/input/inparam.advanced.yaml
@@ -54,9 +54,10 @@ mpi:
     
     # what: weight for load balancing
     # type: string
-    # only: ELEMENT / ELEMENT_POINT
+    # only: ELEMENT / ELEMENT_POINT / NR
     # note: 1) ELEMENT:       use cost measurement on elements
     #       2) ELEMENT_POINT: use cost measurement on both elements and points
+    #       3) NR:            notiming, uses Nr(s,z) weights (reproducible)
     weight_for_load_balancing: ELEMENT_POINT
 
     # what: plot domain decomposition

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -45,11 +45,17 @@ main(int argc, char* argv[]) {
     eigen::DColX nrWeights = computeNrFieldAndWeights(*exodusMesh);
     timer::gPreloopTimer.ended("Nr(s,z) and weights", '*');
 
+    const std::string loadBalanceWeight =
+        inparam::gInparamAdvanced.getWithLimits<std::string>("mpi::weight_for_load_balancing",
+            {{"ELEMENT", "ELEMENT"}, {"ELEMENT_POINT", "ELEMENT_POINT"}, {"NR", "NR"}});
+
     // build nr-weighted local mesh
     timer::gPreloopTimer.begin("Nr-weighted local mesh", '*');
     std::unique_ptr<LocalMesh> localMesh =
         buildLocalMesh(*exodusMesh, nrWeights, "Nr(s,z)", "Stage-I");
-    nrWeights.resize(0); // free memory
+    if (loadBalanceWeight != "NR") {
+      nrWeights.resize(0); // free memory unless needed again for Stage-II NR partition
+    }
     timer::gPreloopTimer.ended("Nr-weighted local mesh", '*');
 
     // build 3D models
@@ -94,9 +100,17 @@ main(int argc, char* argv[]) {
     /////////////////////////////////////
     // Stage-II: cost-weighted domain
 
-    // measure cost
+    eigen::DColX stage2PartitionWeights;
     timer::gPreloopTimer.begin("Cost measurement", '*');
-    eigen::DColX costWeights = measureCost(*sem, *exodusMesh, *localMesh, *timeScheme);
+    if (loadBalanceWeight == "NR") {
+      timer::gPreloopTimer.message(
+          "mpi::weight_for_load_balancing: NR — skipping timing; Stage-II METIS uses Nr weights");
+      stage2PartitionWeights = nrWeights;
+    } else {
+      const bool measurePoint = (loadBalanceWeight == "ELEMENT_POINT");
+      stage2PartitionWeights =
+          measureCost(*sem, *exodusMesh, *localMesh, *timeScheme, measurePoint);
+    }
     timer::gPreloopTimer.ended("Cost measurement", '*');
 
     // free memory
@@ -106,10 +120,13 @@ main(int argc, char* argv[]) {
     domain.reset();
     timer::gPreloopTimer.ended("Freeing memory Stage-I", '*');
 
-    // build cost-weighted local mesh
+    // build Stage-II local mesh (cost- or Nr-weighted partition)
     timer::gPreloopTimer.begin("Cost-weighted local mesh", '*');
-    localMesh = buildLocalMesh(*exodusMesh, costWeights, "measured computational cost", "Stage-II");
-    costWeights.resize(0); // free memory
+    const std::string wkey =
+        (loadBalanceWeight == "NR") ? "Nr(s,z)" : "measured computational cost";
+    localMesh = buildLocalMesh(*exodusMesh, stage2PartitionWeights, wkey, "Stage-II");
+    stage2PartitionWeights.resize(0); // free memory
+    nrWeights.resize(0);
     timer::gPreloopTimer.ended("Cost-weighted local mesh", '*');
 
     // rebuild MPI-dependent 3D models
@@ -561,9 +578,8 @@ eigen::DColX
 measureCost(const SE_Model& sem,
     const ExodusMesh& exodusMesh,
     const LocalMesh& localMesh,
-    const TimeScheme& timeScheme) {
-  bool measurePoint = inparam::gInparamAdvanced.getWithLimits<bool>(
-      "mpi::weight_for_load_balancing", {{"ELEMENT", false}, {"ELEMENT_POINT", true}});
+    const TimeScheme& timeScheme,
+    bool measurePoint) {
   return sem.measureCost(exodusMesh, localMesh, timeScheme, measurePoint);
 }
 

--- a/src/main.hpp
+++ b/src/main.hpp
@@ -119,7 +119,8 @@ eigen::DColX
 measureCost(const SE_Model& sem,
     const ExodusMesh& exodusMesh,
     const LocalMesh& localMesh,
-    const TimeScheme& timeScheme);
+    const TimeScheme& timeScheme,
+    bool measurePoint);
 
 // release sources
 void

--- a/tests/00_global_1D/input/inparam.advanced.yaml
+++ b/tests/00_global_1D/input/inparam.advanced.yaml
@@ -57,7 +57,7 @@ mpi:
     # only: ELEMENT / ELEMENT_POINT
     # note: 1) ELEMENT:       use cost measurement on elements
     #       2) ELEMENT_POINT: use cost measurement on both elements and points
-    weight_for_load_balancing: ELEMENT_POINT
+    weight_for_load_balancing: NR
 
     # what: plot domain decomposition
     # type: bool

--- a/tests/00_global_1D/screen-output
+++ b/tests/00_global_1D/screen-output
@@ -174,7 +174,7 @@ Solid-fluid boundary____________________________________________
   Σ                                     =  514
 Domain decomposition____________________________________________
   # sub-domains (nproc)                 =  3
-  # rank-to-rank communications         =  3
+  # rank-to-rank communications         =  2
 ================================================================
 
 

--- a/tests/01_S362ANI_EMC_global/input/inparam.advanced.yaml
+++ b/tests/01_S362ANI_EMC_global/input/inparam.advanced.yaml
@@ -57,7 +57,7 @@ mpi:
     # only: ELEMENT / ELEMENT_POINT
     # note: 1) ELEMENT:       use cost measurement on elements
     #       2) ELEMENT_POINT: use cost measurement on both elements and points
-    weight_for_load_balancing: ELEMENT_POINT
+    weight_for_load_balancing: NR
 
     # what: plot domain decomposition
     # type: bool

--- a/tests/01_S362ANI_EMC_global/screen-output
+++ b/tests/01_S362ANI_EMC_global/screen-output
@@ -190,7 +190,7 @@ Solid-fluid boundary____________________________________________
   Σ                                     =  514
 Domain decomposition____________________________________________
   # sub-domains (nproc)                 =  4
-  # rank-to-rank communications         =  5
+  # rank-to-rank communications         =  4
 ================================================================
 
 

--- a/tests/03_salt_body_SEG_local-1D/input/inparam.advanced.yaml
+++ b/tests/03_salt_body_SEG_local-1D/input/inparam.advanced.yaml
@@ -57,7 +57,7 @@ mpi:
     # only: ELEMENT / ELEMENT_POINT
     # note: 1) ELEMENT:       use cost measurement on elements
     #       2) ELEMENT_POINT: use cost measurement on both elements and points
-    weight_for_load_balancing: ELEMENT_POINT
+    weight_for_load_balancing: NR
 
     # what: plot domain decomposition
     # type: bool


### PR DESCRIPTION
The option `weight_for_load_balancing` already existed. The new choice `NR` will disable partitioning based on timing information.