### PR TITLE
feat: abort simulation on NaN in displacement with clear diagnostic

### DIFF
--- a/src/core/domain/Domain.cpp
+++ b/src/core/domain/Domain.cpp
@@ -460,6 +460,7 @@ Domain::finalizeOutput() const {
   for (const std::unique_ptr<ElementOpGroupInFluid>& elgrp : mElementOpGroupInFluids) {
     elgrp->finalize();
   }
+
 }
 
 // do scanning
@@ -571,9 +572,15 @@ Domain::reportScanning() const {
 // check stability
 void
 Domain::checkStability(int tstep, double t, double dt) const {
+  std::shared_ptr<Point> nanPoint = nullptr;
   std::shared_ptr<Point> unstablePoint = nullptr;
+
   // solid
   for (const std::shared_ptr<SolidPoint>& point : mSolidPoints) {
+    if (point->hasNaN()) {
+      nanPoint = point;
+      break;
+    }
     if (!point->stable()) {
       unstablePoint = point;
       break;
@@ -581,8 +588,12 @@ Domain::checkStability(int tstep, double t, double dt) const {
   }
 
   // fluid
-  if (!unstablePoint) {
+  if (!nanPoint && !unstablePoint) {
     for (const std::shared_ptr<FluidPoint>& point : mFluidPoints) {
+      if (point->hasNaN()) {
+        nanPoint = point;
+        break;
+      }
       if (!point->stable()) {
         unstablePoint = point;
         break;
@@ -590,7 +601,26 @@ Domain::checkStability(int tstep, double t, double dt) const {
     }
   }
 
-  // abort if unstable
+  // abort on NaN
+  if (nanPoint) {
+    using namespace bstring;
+    std::stringstream ss;
+    ss << "NaN detected in displacement field, with ΔT = " << dt << " s. || ";
+    ss << "Where NaN occurred: || ";
+    const eigen::DRow2& sz = nanPoint->getCoords();
+    if (geodesy::isCartesian()) {
+      ss << "* (s, z)  =  " << range(sz(0), sz(1), '(', ')') << " || ";
+    } else {
+      const eigen::DRow2& rt = geodesy::sz2rtheta(sz, true);
+      ss << "* (r, θ)  =  " << range(rt(0), rt(1), '(', ')') << " || ";
+    }
+    ss << "When NaN occurred: || ";
+    ss << "* current time  =  " << t << " || ";
+    ss << "* current step  =  " << tstep;
+    throw std::runtime_error("Domain::checkStability || " + ss.str());
+  }
+
+  // abort on blow-up (Inf / overflow)
   if (unstablePoint) {
     using namespace bstring;
     std::stringstream ss;

--- a/src/core/domain/Domain.hpp
+++ b/src/core/domain/Domain.hpp
@@ -236,6 +236,7 @@ class Domain {
   void
   checkStability(int tstep, double t, double dt) const;
 
+
   private:
   ////////////////////// spectral elements //////////////////////
   // points
@@ -288,6 +289,7 @@ class Domain {
 
   ////////////////////// wavefield scanning //////////////////////
   std::unique_ptr<const WavefieldScanning> mWavefieldScanning;
+
 
   ////////////////////////////////////////
   //////////////// static ////////////////

--- a/src/core/point/FluidPoint.hpp
+++ b/src/core/point/FluidPoint.hpp
@@ -81,6 +81,12 @@ class FluidPoint : public Point {
     return mFields.mDispl.allFinite();
   }
 
+  // check for NaN specifically (distinct from Inf blow-up)
+  bool
+  hasNaN() const {
+    return mFields.mDispl.hasNaN();
+  }
+
   // stiff to accel
   void
   computeStiffToAccel();

--- a/src/core/point/SolidPoint.hpp
+++ b/src/core/point/SolidPoint.hpp
@@ -79,6 +79,12 @@ class SolidPoint : public Point {
     return mFields.mDispl.allFinite();
   }
 
+  // check for NaN specifically (distinct from Inf blow-up)
+  bool
+  hasNaN() const {
+    return mFields.mDispl.hasNaN();
+  }
+
   // stiff to accel
   void
   computeStiffToAccel();


### PR DESCRIPTION
- SolidPoint.hpp & FluidPoint.hpp: Added hasNaN() method to detect NaN in displacement field
- Domain.cpp: checkStability() now checks for NaN first before Inf blow-up check
- Provides diagnostic output: current step/time, exact coordinates (Cartesian/spherical), time step size

Resolves NaN detection issue and helps users identify instabilities earlier.