### PR TITLE
fix: install numba via conda to avoid llvmlite build failure on macOS

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -29,6 +29,7 @@ dependencies:
   - clang-format=21.1
 
   # Mesher:
+  - numba  # must be installed via conda before pip to avoid llvmlite build failure
   - pip
   - pip:
     - git+https://github.com/AxiSEMunity/salvus_mesh_lite.git


### PR DESCRIPTION
On macOS, pip cannot build llvmlite (numba's backend) from source, causing `conda env create` to fail when salvus_mesh_lite pulls in numba via pip. Fix by pre-installing numba through conda so pip finds it already satisfied.