### PR TITLE
update conda env to include parallel netcdf

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -21,9 +21,9 @@ dependencies:
   - fftw=3.3.10
   - metis=5.2.1
 
-  # I/O stack (serial, no parallel netcdf)
-  - hdf5=1.14.6
-  - libnetcdf=4.9.3
+  # I/O stack (parallel HDF5 / NetCDF; must match mpich above)
+  - hdf5=1.14.6=*mpi_mpich*
+  - libnetcdf=4.9.3=*mpi_mpich*
 
   # code formatting using clang-format:
   - clang-format=21.1


### PR DESCRIPTION
We currently don't cmake configure with parallel netcdf, but we might as well install the parallel version