### PR TITLE
cmake: fix manual eigen path

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -138,7 +138,11 @@ endif()
 
 # eigen
 set(EIGEN3_DIR "$ENV{EIGEN3_DIR}" CACHE PATH "An optional hint to a Eigen3 installation")
-find_package(Eigen3 3.4 REQUIRED HINTS ${EIGEN3_DIR})
+find_package(Eigen3 3.4 HINTS ${EIGEN3_DIR})
+if (NOT Eigen3_FOUND)
+  message(STATUS "Eigen3 CMake package not found; using FindEigen3.cmake fallback...")
+  find_package(Eigen3 REQUIRED MODULE)
+endif()
 include_directories(${EIGEN3_INCLUDE_DIR})
 
 # boost

--- a/cmake/FindEigen3.cmake
+++ b/cmake/FindEigen3.cmake
@@ -83,6 +83,7 @@ else ()
         ENV EIGEN3_ROOT 
         ENV EIGEN3_ROOT_DIR
         ${EIGEN3_ROOT}
+        ${EIGEN3_DIR}
         PATHS
         ${CMAKE_INSTALL_PREFIX}/include
         ${KDE4_INCLUDE_DIR}


### PR DESCRIPTION
if we can not find a cmake installed eigen3, manually search for the include dir (and use the EIGEN3_DIR hint)