### PR TITLE
Github CI: add ubuntu build

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -58,3 +58,36 @@ jobs:
         run: |
           source $CONDA/etc/profile.d/conda.sh && conda activate axisem3d
           python -m salvus_mesh_lite.interface AxiSEM
+
+  linux-ubuntu:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: setup
+        run: |
+          sudo apt-get update && \
+            sudo DEBIAN_FRONTEND='noninteractive' \
+            DEBCONF_NONINTERACTIVE_SEEN='true' \
+            apt-get install --yes \
+              build-essential \
+              git \
+              curl \
+              python3-pip \
+              cmake \
+              openmpi-bin \
+              libopenmpi-dev \
+              libeigen3-dev \
+              libboost-all-dev \
+              libmetis-dev \
+              netcdf-bin \
+              libnetcdf-dev \
+              libfftw3-dev \
+              libhdf5-dev
+      - name: Configure and build
+        run: |
+          mkdir build
+          cd build
+          cmake ..
+          make -j 4
+      - name: Check executable
+        run: ./build/axisem3d --help

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -152,7 +152,7 @@ if(POLICY CMP0167)
   cmake_policy(SET CMP0167 NEW)
 endif()
 set(BOOST_DIR "$ENV{BOOST_DIR}" CACHE PATH "An optional hint to a Boost installation")
-find_package(Boost 1.85 REQUIRED HINTS ${BOOST_DIR})
+find_package(Boost 1.83 REQUIRED HINTS ${BOOST_DIR})
 include_directories(${Boost_INCLUDE_DIRS})
 
 # FFTW3 (optional prefix: -DFFTW3_DIR= or env FFTW3_DIR; legacy -Dfftw= still accepted)


### PR DESCRIPTION
Add a standard build on ubuntu that uses system dependencies without conda. It seems boost 1.83 is new enough.