### PR TITLE
Add positive-density meshing pipeline for the Mars atmosphere example for local laptop runs

### DIFF
--- a/examples/08_atmosphere_Mars_global/README.md
+++ b/examples/08_atmosphere_Mars_global/README.md
@@ -31,6 +31,13 @@ python -m salvus_mesh_lite.interface AxiSEM \
     --output_filename tayak_atm_10s.e
 ```
 
+For this Mars example, use the example-local pipeline in
+`axisem3d_mars_atm/gen_mesh.sh` instead of meshing the raw `.bm` file
+directly. It first rewrites the atmosphere branch onto a denser,
+positivity-preserving radius grid and then validates that the generated Exodus
+mesh has strictly positive fluid `RHO_*` corner fields before the solver is
+run.
+
 I recommend checking this in Paraview to make sure that vs drops to zero where you think it should, and getting a feel for how much lower dt is in the atmosphere as compared to the ground (which is in a way a measure of inefficiency).
 
 ### 2.3 The inparam files

--- a/examples/08_atmosphere_Mars_global/axisem3d_mars_atm/README.txt
+++ b/examples/08_atmosphere_Mars_global/axisem3d_mars_atm/README.txt
@@ -26,6 +26,12 @@ The command to generate the mesh with an atmosphere is no different to without, 
 
 python -m salvus_mesh_lite.interface AxiSEM --basic.model tayak_atmosphere_30km.bm --basic.period 10 --output_filename tayak_atm_10s.e
 
+For this Mars example, use the example-local pipeline in
+gen_mesh.sh instead of meshing the raw .bm file directly. It first rewrites
+the atmosphere branch onto a denser, positivity-preserving radius grid and
+then validates that the generated Exodus mesh has strictly positive fluid
+RHO_* corner fields before the solver is run.
+
 I recommend checking this in Paraview to make sure that vs drops to zero where you think it should, and getting a feel for how much lower dt is in the atmosphere as compared to the ground (which is in a way a measure of inefficiency).
 
 2.3 The inparam files

--- a/examples/08_atmosphere_Mars_global/axisem3d_mars_atm/gen_mesh.sh
+++ b/examples/08_atmosphere_Mars_global/axisem3d_mars_atm/gen_mesh.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PERIOD="${1:-20}"
+OUTPUT_FILE="${2:-${SCRIPT_DIR}/input/tayak_60km_${PERIOD}s.e}"
+PREP_BM="${SCRIPT_DIR}/tayak_60km_atm_meshing.bm"
+
+python3 "${SCRIPT_DIR}/prepare_positive_atmosphere_bm.py" \
+  --input "${SCRIPT_DIR}/tayak_60km_atm.bm" \
+  --output "${PREP_BM}" \
+  --max-atmosphere-step 100.0
+
+python -m salvus_mesh_lite.interface AxiSEM \
+  --basic.model "${PREP_BM}" \
+  --basic.period "${PERIOD}" \
+  --output_filename "${OUTPUT_FILE}"
+
+python3 "${SCRIPT_DIR}/validate_exodus_fluid_rho.py" "${OUTPUT_FILE}"

--- a/examples/08_atmosphere_Mars_global/axisem3d_mars_atm/prepare_positive_atmosphere_bm.py
+++ b/examples/08_atmosphere_Mars_global/axisem3d_mars_atm/prepare_positive_atmosphere_bm.py
@@ -1,0 +1,169 @@
+#!/usr/bin/env python3
+"""Prepare a mesher-safe .bm file for atmosphere-coupled examples.
+
+This rewrites the atmosphere branch of a SalvusMeshLite background model onto
+a denser radius grid and interpolates density in log-space so the profile
+stays strictly positive. The goal is to prevent nonphysical negative density
+values from being introduced into the generated Exodus mesh.
+"""
+
+from __future__ import annotations
+
+import argparse
+import math
+from pathlib import Path
+
+import numpy as np
+
+
+def split_bm(path: Path):
+    header_lines = []
+    data_lines = []
+    with path.open("r", encoding="utf-8-sig") as f:
+        for line in f:
+            stripped = line.strip()
+            if not stripped:
+                header_lines.append(line)
+                continue
+            token = stripped.split()[0]
+            try:
+                float(token)
+            except ValueError:
+                header_lines.append(line)
+            else:
+                data_lines.append(line)
+    if not data_lines:
+        raise RuntimeError(f"No numeric rows found in {path}")
+    return header_lines, data_lines
+
+
+def parse_columns(header_lines: list[str]) -> list[str]:
+    for line in header_lines:
+        stripped = line.strip()
+        if stripped.upper().startswith("COLUMNS "):
+            return stripped.split()[1:]
+    raise RuntimeError("Could not find a COLUMNS header in the .bm file.")
+
+
+def parse_rows(data_lines: list[str]) -> np.ndarray:
+    rows = [[float(tok) for tok in line.split()] for line in data_lines]
+    return np.array(rows, dtype=float)
+
+
+def get_shear_column_indices(columns: list[str]) -> list[int]:
+    shear_names = [name for name in ("vs", "vsv", "vsh") if name in columns]
+    if not shear_names:
+        raise RuntimeError("Could not identify a shear-velocity column in the .bm file.")
+    return [columns.index(name) for name in shear_names]
+
+
+def find_atmosphere_start(rows: np.ndarray, shear_cols: list[int]) -> int:
+    zero_shear = np.all(np.isclose(rows[:, shear_cols], 0.0), axis=1)
+    tail_start = None
+    for idx in range(len(rows) - 1, -1, -1):
+        if zero_shear[idx]:
+            tail_start = idx
+        else:
+            break
+    if tail_start is None:
+        raise RuntimeError("Could not find a zero-shear atmosphere branch.")
+    return tail_start
+
+
+def interpolate_segment(left: np.ndarray,
+                        right: np.ndarray,
+                        radius_idx: int,
+                        rho_idx: int,
+                        max_step: float) -> list[np.ndarray]:
+    r0 = left[radius_idx]
+    r1 = right[radius_idx]
+    if math.isclose(r0, r1):
+        return [right.copy()]
+
+    span = r1 - r0
+    nseg = max(int(math.ceil(abs(span) / max_step)), 1)
+    radii = np.linspace(r0, r1, nseg + 1)[1:]
+
+    out = []
+    positive_left = left[rho_idx] > 0.0
+    positive_right = right[rho_idx] > 0.0
+    for radius in radii:
+        t = (radius - r0) / span
+        row = left + (right - left) * t
+        row[radius_idx] = radius
+        if positive_left and positive_right:
+            row[rho_idx] = math.exp(
+                math.log(left[rho_idx]) * (1.0 - t) + math.log(right[rho_idx]) * t
+            )
+        if row[rho_idx] <= 0.0:
+            raise RuntimeError(
+                f"Interpolated nonpositive density at radius {radius:.6f} m. "
+                "Decrease --max-atmosphere-step or inspect the source profile."
+            )
+        out.append(row)
+    return out
+
+
+def densify_atmosphere(rows: np.ndarray,
+                       columns: list[str],
+                       max_step: float) -> np.ndarray:
+    radius_idx = columns.index("radius")
+    rho_idx = columns.index("rho")
+    shear_cols = get_shear_column_indices(columns)
+    atm_start = find_atmosphere_start(rows, shear_cols)
+
+    solid_rows = [row.copy() for row in rows[:atm_start]]
+    atmosphere_rows = rows[atm_start:]
+    if np.any(atmosphere_rows[:, rho_idx] <= 0.0):
+        raise RuntimeError("The source atmosphere branch must be strictly positive in density.")
+
+    dense_rows = [atmosphere_rows[0].copy()]
+    for left, right in zip(atmosphere_rows[:-1], atmosphere_rows[1:]):
+        dense_rows.extend(interpolate_segment(left, right, radius_idx, rho_idx, max_step))
+
+    return np.vstack(solid_rows + dense_rows)
+
+
+def format_row(row: np.ndarray) -> str:
+    return "    " + "  ".join(f"{value:.12g}" for value in row) + "\n"
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--input", required=True, help="Input .bm file")
+    parser.add_argument("--output", required=True, help="Output .bm file")
+    parser.add_argument(
+        "--max-atmosphere-step",
+        type=float,
+        default=100.0,
+        help="Maximum radial spacing in meters used when densifying the atmosphere branch",
+    )
+    args = parser.parse_args()
+
+    in_path = Path(args.input).resolve()
+    out_path = Path(args.output).resolve()
+
+    header_lines, data_lines = split_bm(in_path)
+    columns = parse_columns(header_lines)
+    rows = parse_rows(data_lines)
+    dense_rows = densify_atmosphere(rows, columns, args.max_atmosphere_step)
+
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    with out_path.open("w", encoding="utf-8") as f:
+        for line in header_lines:
+            f.write(line)
+        for row in dense_rows:
+            f.write(format_row(row))
+
+    rho_idx = columns.index("rho")
+    print(f"Wrote {out_path}")
+    print(f"Original rows: {rows.shape[0]}")
+    print(f"Prepared rows: {dense_rows.shape[0]}")
+    print(
+        f"Atmosphere density range: [{dense_rows[:, rho_idx].min():.12g}, "
+        f"{dense_rows[:, rho_idx].max():.12g}]"
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/08_atmosphere_Mars_global/axisem3d_mars_atm/validate_exodus_fluid_rho.py
+++ b/examples/08_atmosphere_Mars_global/axisem3d_mars_atm/validate_exodus_fluid_rho.py
@@ -1,0 +1,53 @@
+#!/usr/bin/env python3
+"""Validate that a generated Exodus mesh has strictly positive fluid density."""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+import h5py
+import numpy as np
+
+
+def decode_elem_var_names(mesh: h5py.File) -> list[str]:
+    raw = mesh["name_elem_var"][:]
+    return [
+        b"".join(raw[i]).decode("ascii", errors="ignore").strip().strip("\x00").strip()
+        for i in range(raw.shape[0])
+    ]
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("mesh", help="Path to the Exodus .e mesh file")
+    args = parser.parse_args()
+
+    path = Path(args.mesh).resolve()
+    with h5py.File(path, "r") as mesh:
+        names = decode_elem_var_names(mesh)
+        idx_fluid = names.index("fluid") + 1
+        fluid = mesh[f"vals_elem_var{idx_fluid}eb1"][0] > 0.5
+
+        bad_counts = []
+        for inode in range(4):
+            idx_rho = names.index(f"RHO_{inode}") + 1
+            rho = mesh[f"vals_elem_var{idx_rho}eb1"][0]
+            bad = np.count_nonzero(fluid & (rho <= 0.0))
+            bad_counts.append(bad)
+            print(
+                f"RHO_{inode}: min={rho[fluid].min():.12g}, "
+                f"max={rho[fluid].max():.12g}, nonpositive_fluid_values={bad}"
+            )
+
+    total_bad = sum(bad_counts)
+    if total_bad:
+        raise SystemExit(
+            f"Mesh validation failed: found {total_bad} nonpositive fluid density "
+            f"corner values in {path}"
+        )
+    print(f"Mesh validation passed: all fluid RHO_* values are strictly positive in {path}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

This PR fixes a stability issue in `examples/08_atmosphere_Mars_global` at the meshing pipeline level.

It adds an example-local workflow that:
- preprocesses the Mars atmosphere `.bm` onto a denser radius grid before meshing,
- interpolates density in log-space so the atmosphere profile stays strictly positive,
- validates the generated Exodus mesh and fails fast if any fluid `RHO_*` corner values are nonpositive.

It also updates the example documentation to point users to this safer meshing path.

## Motivation

The original Mars atmosphere example can produce a mesh with nonphysical negative fluid density in the upper atmosphere. Once the wavefield reaches that region, the run becomes unstable and blows up.

This change addresses the issue in the example/model preparation workflow rather than in the solver itself:
- no core `src/` solver code is modified,
- the fix is localized to the example’s meshing pipeline,
- mesh validation now catches the bad state before the solver is launched.

## Changes

- add `axisem3d_mars_atm/prepare_positive_atmosphere_bm.py`
- add `axisem3d_mars_atm/validate_exodus_fluid_rho.py`
- add `axisem3d_mars_atm/gen_mesh.sh`
- update `examples/08_atmosphere_Mars_global/README.md`
- update `examples/08_atmosphere_Mars_global/axisem3d_mars_atm/README.txt`
