### PR TITLE
add check for positive density

### DIFF
--- a/src/preloop/se_model/quad/physical/Material.cpp
+++ b/src/preloop/se_model/quad/physical/Material.cpp
@@ -243,6 +243,17 @@ Material::getPointwiseRhoVpVs(
     eigen::arN_DColX& rho, eigen::arN_DColX& vp, eigen::arN_DColX& vs) const {
   // density
   rho = getProperty("RHO").getPointwise();
+
+  {
+    // check for positive density
+    for (int ipnt = 0; ipnt < spectral::nPEM; ipnt++) {
+      if (rho[ipnt].minCoeff() < numerical::dEpsilon) {
+        throw std::runtime_error("Material::getPointwiseRhoVpVs || "
+                                 "Density is not positive.");
+      }
+    }
+  }
+
   if (currentRheology() == RheologyType::FLUID) {
     vp = getProperty("VP").getPointwise();
     // vs = 0


### PR DESCRIPTION
This checks that the density RHO from the input mesh is positive in each point.

Based on the conversation in https://github.com/AxiSEMunity/AxiSEM3D/pull/229#issuecomment-4261865333

@ytian159 could you check if this works correctly? I was trying to use the unmodified mesh in example 08, but I am getting a NetCDF open() error for some reason.