### PR TITLE
CMake: fix variable type for SKIP_MM_SET

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -96,7 +96,7 @@ if(USE_PARALLEL_NETCDF)
 endif()
 
 # skip _MM_SET_FLUSH_ZERO_MODE in fenv.cpp
-set(SKIP_MM_SET OFF CACHE BUILD "if ON, skip _MM_SET_FLUSH_ZERO_MODE in fenv.cpp")
+set(SKIP_MM_SET OFF CACHE BOOL "if ON, skip _MM_SET_FLUSH_ZERO_MODE in fenv.cpp")
 if(SKIP_MM_SET)
   add_definitions(-DAXISEM3D_SKIP_DISABLE_SSE_DENORMS)
 endif()


### PR DESCRIPTION
this gets rid of 
```
CMake Warning (dev) at CMakeLists.txt:99 (set):                                                                             
  implicitly converting 'BUILD' to 'STRING' type.                                                                           
This warning is for project developers.  Use -Wno-dev to suppress it.                                                       
```