### PR TITLE
update git ignore to include the output folders in the examples directories

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,6 +42,8 @@ simu_with_3d_crust/
 .ipynb_checkpoints/
 build*/
 .cache/
+examples/*/output/
+examples/*/output__backup_at_*/
 
 # Documentation
 .venv


### PR DESCRIPTION
This pull request should make it so that when running the examples, the output directories are ignored by git.