### PR TITLE
Rename namespace eigen to axisem3deigen

### DIFF
--- a/src/core/boundary/ABC/ClaytonFluid1D.cpp
+++ b/src/core/boundary/ABC/ClaytonFluid1D.cpp
@@ -16,8 +16,8 @@
 void
 ClaytonFluid1D::apply() const {
   // get fields
-  const eigen::CColX& veloc = mFluidPoint->getFields().mVeloc;
-  eigen::CColX& stiff = mFluidPoint->getFields().mStiff;
+  const axisem3d::eigen::CColX& veloc = mFluidPoint->getFields().mVeloc;
+  axisem3d::eigen::CColX& stiff = mFluidPoint->getFields().mStiff;
 
   // apply
   stiff -= veloc * mAreaOverRhoVp;

--- a/src/core/boundary/ABC/ClaytonFluid3D.cpp
+++ b/src/core/boundary/ABC/ClaytonFluid3D.cpp
@@ -37,8 +37,8 @@ ClaytonFluid3D::checkCompatibility() {
 void
 ClaytonFluid3D::apply() const {
   // get fields
-  const eigen::CColX& veloc = mFluidPoint->getFields().mVeloc;
-  eigen::CColX& stiff = mFluidPoint->getFields().mStiff;
+  const axisem3d::eigen::CColX& veloc = mFluidPoint->getFields().mVeloc;
+  axisem3d::eigen::CColX& stiff = mFluidPoint->getFields().mStiff;
 
   // constants
   int nr = mFluidPoint->getNr();

--- a/src/core/boundary/ABC/ClaytonFluid3D.hpp
+++ b/src/core/boundary/ABC/ClaytonFluid3D.hpp
@@ -18,8 +18,9 @@
 class ClaytonFluid3D : public ClaytonFluid {
   public:
   // constructor
-  ClaytonFluid3D(
-      const std::shared_ptr<FluidPoint>& fp, const eigen::DColX& rhoVp, const eigen::DColX& area) :
+  ClaytonFluid3D(const std::shared_ptr<FluidPoint>& fp,
+      const axisem3d::eigen::DColX& rhoVp,
+      const axisem3d::eigen::DColX& area) :
       ClaytonFluid(fp), mAreaOverRhoVp(area.cwiseQuotient(rhoVp).cast<numerical::Real>()) {
     // check compatibility
     checkCompatibility();
@@ -37,15 +38,15 @@ class ClaytonFluid3D : public ClaytonFluid {
 
   private:
   // area / (rho * vp)
-  const eigen::RColX mAreaOverRhoVp;
+  const axisem3d::eigen::RColX mAreaOverRhoVp;
 
   ////////////////////////////////////////
   //////////////// static ////////////////
   ////////////////////////////////////////
 
   // workspace
-  inline static eigen::RColX sVecR = eigen::RColX(0);
-  inline static eigen::CColX sVecC = eigen::CColX(0);
+  inline static axisem3d::eigen::RColX sVecR = axisem3d::eigen::RColX(0);
+  inline static axisem3d::eigen::CColX sVecC = axisem3d::eigen::CColX(0);
 };
 
 #endif /* ClaytonFluid3D_hpp */

--- a/src/core/boundary/ABC/ClaytonSolid1D.cpp
+++ b/src/core/boundary/ABC/ClaytonSolid1D.cpp
@@ -17,8 +17,8 @@
 void
 ClaytonSolid1D::apply() const {
   // get fields
-  const eigen::CMatX3& veloc = mSolidPoint->getFields().mVeloc;
-  eigen::CMatX3& stiff = mSolidPoint->getFields().mStiff;
+  const axisem3d::eigen::CMatX3& veloc = mSolidPoint->getFields().mVeloc;
+  axisem3d::eigen::CMatX3& stiff = mSolidPoint->getFields().mStiff;
 
   // s, z
   stiff.col(0) -= (mRSA_CosT2_p_RPA_SinT2 * veloc.col(0) + mRPA_m_RSA_x_CosT_SinT * veloc.col(2));

--- a/src/core/boundary/ABC/ClaytonSolid3D.cpp
+++ b/src/core/boundary/ABC/ClaytonSolid3D.cpp
@@ -45,8 +45,8 @@ ClaytonSolid3D::checkCompatibility() {
 void
 ClaytonSolid3D::apply() const {
   // get fields
-  const eigen::CMatX3& veloc = mSolidPoint->getFields().mVeloc;
-  eigen::CMatX3& stiff = mSolidPoint->getFields().mStiff;
+  const axisem3d::eigen::CMatX3& veloc = mSolidPoint->getFields().mVeloc;
+  axisem3d::eigen::CMatX3& stiff = mSolidPoint->getFields().mStiff;
 
   // constants
   int nr = (int)mRSA.rows();

--- a/src/core/boundary/ABC/ClaytonSolid3D.hpp
+++ b/src/core/boundary/ABC/ClaytonSolid3D.hpp
@@ -26,10 +26,10 @@ class ClaytonSolid3D : public ClaytonSolid {
   public:
   // constructor
   ClaytonSolid3D(const std::shared_ptr<SolidPoint>& sp,
-      const eigen::DColX& rhoVp,
-      const eigen::DColX& rhoVs,
-      const eigen::DColX& area,
-      const eigen::DMatX3& unitNormal) :
+      const axisem3d::eigen::DColX& rhoVp,
+      const axisem3d::eigen::DColX& rhoVs,
+      const axisem3d::eigen::DColX& area,
+      const axisem3d::eigen::DMatX3& unitNormal) :
       ClaytonSolid(sp), mRSA(rhoVs.cwiseProduct(area).cast<numerical::Real>()),
       mK(((rhoVp - rhoVs).cwiseProduct(area).cwiseSqrt().asDiagonal() * unitNormal)
               .cast<numerical::Real>()) {
@@ -49,9 +49,9 @@ class ClaytonSolid3D : public ClaytonSolid {
 
   private:
   // rsa = rho * vs * area
-  const eigen::RColX mRSA;
+  const axisem3d::eigen::RColX mRSA;
   // k = sqrt(rpa - rsa) n
-  const eigen::RMatX3 mK;
+  const axisem3d::eigen::RMatX3 mK;
 
   ////////////////////////////////////////
   //////////////// static ////////////////
@@ -60,10 +60,10 @@ class ClaytonSolid3D : public ClaytonSolid {
   private:
   // workspace
   // V = FFT(velocity)
-  inline static eigen::RMatX3 sVR = eigen::RMatX3(0, 3);
+  inline static axisem3d::eigen::RMatX3 sVR = axisem3d::eigen::RMatX3(0, 3);
   // a = rsa V + V.k k
-  inline static eigen::RMatX3 sAR = eigen::RMatX3(0, 3);
-  inline static eigen::CMatX3 sAC = eigen::CMatX3(0, 3);
+  inline static axisem3d::eigen::RMatX3 sAR = axisem3d::eigen::RMatX3(0, 3);
+  inline static axisem3d::eigen::CMatX3 sAC = axisem3d::eigen::CMatX3(0, 3);
 };
 
 #endif /* ClaytonSolid3D_hpp */

--- a/src/core/boundary/ABC/Sponge.hpp
+++ b/src/core/boundary/ABC/Sponge.hpp
@@ -34,12 +34,12 @@ template <class PointSF> class Sponge {
   public:
   // 1D constructor
   Sponge(const std::shared_ptr<PointSF>& point, double gamma) :
-      mPoint(point), mGamma((eigen::RColX(1) << gamma).finished()) {
+      mPoint(point), mGamma((axisem3d::eigen::RColX(1) << gamma).finished()) {
     // nothing
   }
 
   // 3D constructor
-  Sponge(const std::shared_ptr<PointSF>& point, const eigen::DColX& gamma) :
+  Sponge(const std::shared_ptr<PointSF>& point, const axisem3d::eigen::DColX& gamma) :
       mPoint(point), mGamma(gamma.cast<numerical::Real>()) {
     // check size
     int nr = (int)gamma.rows();
@@ -98,7 +98,7 @@ template <class PointSF> class Sponge {
   const std::shared_ptr<PointSF> mPoint;
 
   // gamma
-  const eigen::RColX mGamma;
+  const axisem3d::eigen::RColX mGamma;
 
   //////////////////// static ////////////////////
   // 3D workspace

--- a/src/core/boundary/axial/AxialBoundary.cpp
+++ b/src/core/boundary/axial/AxialBoundary.cpp
@@ -27,7 +27,7 @@ AxialBoundary::apply() const {
 
   // solid
   for (const std::shared_ptr<SolidPoint>& sp : mSolidPoints) {
-    eigen::CMatX3& stiff = sp->getFields().mStiff;
+    axisem3d::eigen::CMatX3& stiff = sp->getFields().mStiff;
     int nu = sp->getNu_1() - 1;
 
     // alpha = 0

--- a/src/core/boundary/solid_fluid/SolidFluidCoupling.hpp
+++ b/src/core/boundary/solid_fluid/SolidFluidCoupling.hpp
@@ -45,11 +45,13 @@ class SolidFluidCoupling {
   public:
   // solid => fluid
   virtual void
-  coupleSolidToFluid(const eigen::CMatX3& solidDispl, eigen::CColX& fluidStiff) const = 0;
+  coupleSolidToFluid(
+      const axisem3d::eigen::CMatX3& solidDispl, axisem3d::eigen::CColX& fluidStiff) const = 0;
 
   // fluid => solid
   virtual void
-  coupleFluidToSolid(const eigen::CColX& fluidStiff, eigen::CMatX3& solidStiff) const = 0;
+  coupleFluidToSolid(
+      const axisem3d::eigen::CColX& fluidStiff, axisem3d::eigen::CMatX3& solidStiff) const = 0;
 
   protected:
   // coupled solid-fluid pair

--- a/src/core/boundary/solid_fluid/SolidFluidCoupling1D.hpp
+++ b/src/core/boundary/solid_fluid/SolidFluidCoupling1D.hpp
@@ -27,14 +27,16 @@ class SolidFluidCoupling1D : public SolidFluidCoupling {
 
   // solid => fluid
   void
-  coupleSolidToFluid(const eigen::CMatX3& solidDispl, eigen::CColX& fluidStiff) const {
+  coupleSolidToFluid(
+      const axisem3d::eigen::CMatX3& solidDispl, axisem3d::eigen::CColX& fluidStiff) const {
     fluidStiff += mNormalS_UnassembledMPI * solidDispl.col(0);
     fluidStiff += mNormalZ_UnassembledMPI * solidDispl.col(2);
   }
 
   // fluid => solid
   void
-  coupleFluidToSolid(const eigen::CColX& fluidStiff, eigen::CMatX3& solidStiff) const {
+  coupleFluidToSolid(
+      const axisem3d::eigen::CColX& fluidStiff, axisem3d::eigen::CMatX3& solidStiff) const {
     solidStiff.col(0) -= mNormalS_AssembledMPI_InvMassFluid * fluidStiff;
     solidStiff.col(2) -= mNormalZ_AssembledMPI_InvMassFluid * fluidStiff;
   }

--- a/src/core/boundary/solid_fluid/SolidFluidCoupling3D.cpp
+++ b/src/core/boundary/solid_fluid/SolidFluidCoupling3D.cpp
@@ -16,9 +16,9 @@
 // constructor
 SolidFluidCoupling3D::SolidFluidCoupling3D(const std::shared_ptr<SolidPoint>& sp,
     const std::shared_ptr<FluidPoint>& fp,
-    const eigen::DMatX3& n_unassmb,
-    const eigen::DMatX3& n_assmb,
-    const eigen::DColX& massFluid) :
+    const axisem3d::eigen::DMatX3& n_unassmb,
+    const axisem3d::eigen::DMatX3& n_assmb,
+    const axisem3d::eigen::DColX& massFluid) :
     SolidFluidCoupling(sp, fp), mNormal_UnassembledMPI(n_unassmb.cast<numerical::Real>()),
     mNormal_AssembledMPI_InvMassFluid(
         (massFluid.cwiseInverse().asDiagonal() * n_assmb).cast<numerical::Real>()) {
@@ -54,7 +54,7 @@ SolidFluidCoupling3D::checkCompatibility(int nr) const {
 // solid => fluid
 void
 SolidFluidCoupling3D::coupleSolidToFluid(
-    const eigen::CMatX3& solidDispl, eigen::CColX& fluidStiff) const {
+    const axisem3d::eigen::CMatX3& solidDispl, axisem3d::eigen::CColX& fluidStiff) const {
   // constants
   int nr = (int)mNormal_UnassembledMPI.rows();
   int nu_1 = nr / 2 + 1;
@@ -75,7 +75,7 @@ SolidFluidCoupling3D::coupleSolidToFluid(
 // fluid => solid
 void
 SolidFluidCoupling3D::coupleFluidToSolid(
-    const eigen::CColX& fluidStiff, eigen::CMatX3& solidStiff) const {
+    const axisem3d::eigen::CColX& fluidStiff, axisem3d::eigen::CMatX3& solidStiff) const {
   // constants
   int nr = (int)mNormal_UnassembledMPI.rows();
   int nu_1 = nr / 2 + 1;

--- a/src/core/boundary/solid_fluid/SolidFluidCoupling3D.hpp
+++ b/src/core/boundary/solid_fluid/SolidFluidCoupling3D.hpp
@@ -19,9 +19,9 @@ class SolidFluidCoupling3D : public SolidFluidCoupling {
   // constructor
   SolidFluidCoupling3D(const std::shared_ptr<SolidPoint>& sp,
       const std::shared_ptr<FluidPoint>& fp,
-      const eigen::DMatX3& n_unassmb,
-      const eigen::DMatX3& n_assmb,
-      const eigen::DColX& massFluid);
+      const axisem3d::eigen::DMatX3& n_unassmb,
+      const axisem3d::eigen::DMatX3& n_assmb,
+      const axisem3d::eigen::DColX& massFluid);
 
   private:
   // check compatibility
@@ -31,28 +31,30 @@ class SolidFluidCoupling3D : public SolidFluidCoupling {
   public:
   // solid => fluid
   void
-  coupleSolidToFluid(const eigen::CMatX3& solidDispl, eigen::CColX& fluidStiff) const;
+  coupleSolidToFluid(
+      const axisem3d::eigen::CMatX3& solidDispl, axisem3d::eigen::CColX& fluidStiff) const;
 
   // fluid => solid
   void
-  coupleFluidToSolid(const eigen::CColX& fluidStiff, eigen::CMatX3& solidStiff) const;
+  coupleFluidToSolid(
+      const axisem3d::eigen::CColX& fluidStiff, axisem3d::eigen::CMatX3& solidStiff) const;
 
   private:
   // These two normal vectors enable isochronous MPI communication for solid
   // and fluid domains. Though it is bad practice to mix MPI and physics,
   // but this trick can lead to significant performance boost.
-  const eigen::RMatX3 mNormal_UnassembledMPI;
-  const eigen::RMatX3 mNormal_AssembledMPI_InvMassFluid;
+  const axisem3d::eigen::RMatX3 mNormal_UnassembledMPI;
+  const axisem3d::eigen::RMatX3 mNormal_AssembledMPI_InvMassFluid;
 
   ////////////////////////////////////////
   //////////////// static ////////////////
   ////////////////////////////////////////
 
   // workspace
-  inline static eigen::RMatX3 sSolidR = eigen::RMatX3(0, 3);
-  inline static eigen::CMatX3 sSolidC = eigen::CMatX3(0, 3);
-  inline static eigen::RColX sFluidR = eigen::RColX(0);
-  inline static eigen::CColX sFluidC = eigen::CColX(0);
+  inline static axisem3d::eigen::RMatX3 sSolidR = axisem3d::eigen::RMatX3(0, 3);
+  inline static axisem3d::eigen::CMatX3 sSolidC = axisem3d::eigen::CMatX3(0, 3);
+  inline static axisem3d::eigen::RColX sFluidR = axisem3d::eigen::RColX(0);
+  inline static axisem3d::eigen::CColX sFluidC = axisem3d::eigen::CColX(0);
 };
 
 #endif /* SolidFluidCoupling3D_hpp */

--- a/src/core/domain/Domain.cpp
+++ b/src/core/domain/Domain.cpp
@@ -539,9 +539,9 @@ Domain::reportScanning() const {
   // write to file
   if (mpi::root()) {
     // flatten buffer
-    eigen::DMatXX_RM sz(nPoints, 2);
-    eigen::IColX nrOrig(nPoints);
-    eigen::IColX nrScan(nPoints);
+    axisem3d::eigen::DMatXX_RM sz(nPoints, 2);
+    axisem3d::eigen::IColX nrOrig(nPoints);
+    axisem3d::eigen::IColX nrScan(nPoints);
     nPoints = 0;
     for (int iproc = 0; iproc < mpi::nproc(); iproc++) {
       for (int ipnt = 0; ipnt < szBufferAll[iproc].size() / 2; ipnt++) {
@@ -596,11 +596,11 @@ Domain::checkStability(int tstep, double t, double dt) const {
     std::stringstream ss;
     ss << "Simulation has blown up, with ΔT = " << dt << " s. || ";
     ss << "Where the instability occurred: || ";
-    const eigen::DRow2& sz = unstablePoint->getCoords();
+    const axisem3d::eigen::DRow2& sz = unstablePoint->getCoords();
     if (geodesy::isCartesian()) {
       ss << "* (s, z)  =  " << range(sz(0), sz(1), '(', ')') << " || ";
     } else {
-      const eigen::DRow2& rt = geodesy::sz2rtheta(sz, true);
+      const axisem3d::eigen::DRow2& rt = geodesy::sz2rtheta(sz, true);
       ss << "* (r, θ)  =  " << range(rt(0), rt(1), '(', ')') << " || ";
     }
     ss << "When the instability occurred: || ";

--- a/src/core/domain/MessageRank.cpp
+++ b/src/core/domain/MessageRank.cpp
@@ -33,8 +33,8 @@ MessageRank::allocateBuffer() {
       sizeComm += fp->sizeComm();
     }
   }
-  mBufferSend = eigen::CColX::Zero(sizeComm);
-  mBufferRecv = eigen::CColX::Zero(sizeComm);
+  mBufferSend = axisem3d::eigen::CColX::Zero(sizeComm);
+  mBufferRecv = axisem3d::eigen::CColX::Zero(sizeComm);
 }
 
 // gather from points

--- a/src/core/domain/MessageRank.hpp
+++ b/src/core/domain/MessageRank.hpp
@@ -78,8 +78,8 @@ class MessageRank {
   std::vector<MeshPoint> mMeshPoints;
 
   // buffers
-  eigen::CColX mBufferSend = eigen::CColX(0);
-  eigen::CColX mBufferRecv = eigen::CColX(0);
+  axisem3d::eigen::CColX mBufferSend = axisem3d::eigen::CColX(0);
+  axisem3d::eigen::CColX mBufferRecv = axisem3d::eigen::CColX(0);
 };
 
 #endif /* MessageRank_hpp */

--- a/src/core/element/Element.cpp
+++ b/src/core/element/Element.cpp
@@ -75,10 +75,10 @@ Element::findBoundaryPointsByCrds(const std::vector<double>& boundaryCrdsRorZ,
   const std::vector<int>& allSidePoints = vicinity::constants::gEdgeIPntAll;
 
   // collect coords
-  eigen::DColX crdRorZ(nPEM);
-  eigen::DColX crdTorS(nPEM);
+  axisem3d::eigen::DColX crdRorZ(nPEM);
+  axisem3d::eigen::DColX crdTorS(nPEM);
   for (int ipnt = 0; ipnt < nPEM; ipnt++) {
-    const eigen::DRow2& sz = getPoint(ipnt).getCoords();
+    const axisem3d::eigen::DRow2& sz = getPoint(ipnt).getCoords();
     if (geodesy::isCartesian()) {
       crdRorZ(ipnt) = sz(1);
       crdTorS(ipnt) = sz(0);
@@ -138,12 +138,12 @@ Element::createCoordTransform() {
       mTransform = std::make_unique<const CoordTransformCartesian>();
     } else {
       // compute theta
-      eigen::DMatPP_RM theta;
+      axisem3d::eigen::DMatPP_RM theta;
       for (int ipol = 0; ipol < spectral::nPED; ipol++) {
         for (int jpol = 0; jpol < spectral::nPED; jpol++) {
           int ipnt = ipol * spectral::nPED + jpol;
-          const eigen::DRow2& sz = getPoint(ipnt).getCoords();
-          const eigen::DRow2& rt = geodesy::sz2rtheta(sz, true);
+          const axisem3d::eigen::DRow2& sz = getPoint(ipnt).getCoords();
+          const axisem3d::eigen::DRow2& rt = geodesy::sz2rtheta(sz, true);
           theta(ipol, jpol) = rt(1);
         }
       }

--- a/src/core/element/FluidElement.cpp
+++ b/src/core/element/FluidElement.cpp
@@ -88,7 +88,7 @@ FluidElement::getPoint(int ipnt) const {
 /////////////////////////// time loop ///////////////////////////
 // collect displacement from points
 void
-FluidElement::collectDisplFromPoints(eigen::vec_ar1_CMatPP_RM& displElem) const {
+FluidElement::collectDisplFromPoints(axisem3d::eigen::vec_ar1_CMatPP_RM& displElem) const {
   for (int ipol = 0; ipol < spectral::nPED; ipol++) {
     for (int jpol = 0; jpol < spectral::nPED; jpol++) {
       mPoints[ipol * spectral::nPED + jpol]->scatterDisplToElement(displElem, mNu_1, ipol, jpol);
@@ -98,8 +98,8 @@ FluidElement::collectDisplFromPoints(eigen::vec_ar1_CMatPP_RM& displElem) const 
 
 // displacement to stiffness
 void
-FluidElement::displToStiff(
-    const eigen::vec_ar1_CMatPP_RM& displElem, eigen::vec_ar1_CMatPP_RM& stiffElem) const {
+FluidElement::displToStiff(const axisem3d::eigen::vec_ar1_CMatPP_RM& displElem,
+    axisem3d::eigen::vec_ar1_CMatPP_RM& stiffElem) const {
   // displ => strain
   mGradQuad->computeGrad3(displElem, sStrainSpherical_FR, mNu_1);
 
@@ -135,7 +135,7 @@ FluidElement::displToStiff(
 // add stiffness to points
 // allow a derived class to change stiffElem (no const)
 void
-FluidElement::addStiffToPoints(eigen::vec_ar1_CMatPP_RM& stiffElem) const {
+FluidElement::addStiffToPoints(axisem3d::eigen::vec_ar1_CMatPP_RM& stiffElem) const {
   for (int ipol = 0; ipol < spectral::nPED; ipol++) {
     for (int jpol = 0; jpol < spectral::nPED; jpol++) {
       mPoints[ipol * spectral::nPED + jpol]->gatherStiffFromElement(stiffElem, ipol, jpol);
@@ -189,7 +189,7 @@ FluidElement::preparePressureSource() const {
 
 // add pressure source
 void
-FluidElement::addPressureSource(const eigen::CMatXN& pressure, int nu_1_pressure) const {
+FluidElement::addPressureSource(const axisem3d::eigen::CMatXN& pressure, int nu_1_pressure) const {
   for (int ipnt = 0; ipnt < nPEM; ipnt++) {
     mPoints[ipnt]->addPressureSource(pressure, nu_1_pressure, ipnt);
   }
@@ -225,7 +225,7 @@ FluidElement::prepareWavefieldOutput(
 
 // chi field
 void
-FluidElement::getChiField(eigen::CMatXN& chi) const {
+FluidElement::getChiField(axisem3d::eigen::CMatXN& chi) const {
   // collect displacement from points
   collectDisplFromPoints(sDisplSpherical_FR);
 
@@ -235,7 +235,7 @@ FluidElement::getChiField(eigen::CMatXN& chi) const {
 
 // displ field
 void
-FluidElement::getDisplField(eigen::CMatXN3& displ, bool needRTZ) const {
+FluidElement::getDisplField(axisem3d::eigen::CMatXN3& displ, bool needRTZ) const {
   // collect displacement from points
   collectDisplFromPoints(sDisplSpherical_FR);
 
@@ -278,7 +278,7 @@ FluidElement::getDisplField(eigen::CMatXN3& displ, bool needRTZ) const {
 
 // pressure field
 void
-FluidElement::getPressureField(eigen::CMatXN& pressure) const {
+FluidElement::getPressureField(axisem3d::eigen::CMatXN& pressure) const {
   for (int ipnt = 0; ipnt < nPEM; ipnt++) {
     mPoints[ipnt]->scatterPressureToElement(pressure, mNu_1, ipnt);
   }
@@ -286,7 +286,7 @@ FluidElement::getPressureField(eigen::CMatXN& pressure) const {
 
 // delta field
 void
-FluidElement::getDeltaField(eigen::CMatXN& delta) const {
+FluidElement::getDeltaField(axisem3d::eigen::CMatXN& delta) const {
   for (int ipnt = 0; ipnt < nPEM; ipnt++) {
     mPoints[ipnt]->scatterDeltaToElement(delta, mNu_1, ipnt);
   }

--- a/src/core/element/FluidElement.hpp
+++ b/src/core/element/FluidElement.hpp
@@ -60,17 +60,17 @@ class FluidElement : public Element {
   /////////////////////////// time loop ///////////////////////////
   // collect displacement from points
   virtual void
-  collectDisplFromPoints(eigen::vec_ar1_CMatPP_RM& displElem) const;
+  collectDisplFromPoints(axisem3d::eigen::vec_ar1_CMatPP_RM& displElem) const;
 
   // displacement to stiffness
   void
-  displToStiff(
-      const eigen::vec_ar1_CMatPP_RM& displElem, eigen::vec_ar1_CMatPP_RM& stiffElem) const;
+  displToStiff(const axisem3d::eigen::vec_ar1_CMatPP_RM& displElem,
+      axisem3d::eigen::vec_ar1_CMatPP_RM& stiffElem) const;
 
   // add stiffness to points
   // allow a derived class to change stiffElem (no const)
   virtual void
-  addStiffToPoints(eigen::vec_ar1_CMatPP_RM& stiffElem) const;
+  addStiffToPoints(axisem3d::eigen::vec_ar1_CMatPP_RM& stiffElem) const;
 
   // compute stiffness term
   void
@@ -87,7 +87,7 @@ class FluidElement : public Element {
 
   // add pressure source
   void
-  addPressureSource(const eigen::CMatXN& pressure, int nu_1_pressure) const;
+  addPressureSource(const axisem3d::eigen::CMatXN& pressure, int nu_1_pressure) const;
 
   /////////////////////////// wavefield output ///////////////////////////
   // prepare wavefield output
@@ -96,25 +96,25 @@ class FluidElement : public Element {
 
   // chi field
   void
-  getChiField(eigen::CMatXN& chi) const;
+  getChiField(axisem3d::eigen::CMatXN& chi) const;
 
   // displ field
   void
-  getDisplField(eigen::CMatXN3& displ) const {
+  getDisplField(axisem3d::eigen::CMatXN3& displ) const {
     getDisplField(displ, displInRTZ());
   }
 
   // displ field
   void
-  getDisplField(eigen::CMatXN3& displ, bool needRTZ) const;
+  getDisplField(axisem3d::eigen::CMatXN3& displ, bool needRTZ) const;
 
   // pressure field
   void
-  getPressureField(eigen::CMatXN& pressure) const;
+  getPressureField(axisem3d::eigen::CMatXN& pressure) const;
 
   // delta field
   void
-  getDeltaField(eigen::CMatXN& delta) const;
+  getDeltaField(axisem3d::eigen::CMatXN& delta) const;
 
   // displ crd
   inline bool
@@ -156,17 +156,21 @@ class FluidElement : public Element {
 
   // workspace
   // Fourier
-  inline static eigen::vec_ar1_CMatPP_RM sDisplSpherical_FR;
-  inline static eigen::vec_ar3_CMatPP_RM sStrainSpherical_FR;
-  inline static eigen::vec_ar3_CMatPP_RM sStrainUndulated_FR;
-  inline static eigen::vec_ar3_CMatPP_RM sStressUndulated_FR;
-  inline static eigen::vec_ar3_CMatPP_RM sStressSpherical_FR;
-  inline static eigen::vec_ar1_CMatPP_RM sStiffSpherical_FR;
+  inline static axisem3d::eigen::vec_ar1_CMatPP_RM sDisplSpherical_FR;
+  inline static axisem3d::eigen::vec_ar3_CMatPP_RM sStrainSpherical_FR;
+  inline static axisem3d::eigen::vec_ar3_CMatPP_RM sStrainUndulated_FR;
+  inline static axisem3d::eigen::vec_ar3_CMatPP_RM sStressUndulated_FR;
+  inline static axisem3d::eigen::vec_ar3_CMatPP_RM sStressSpherical_FR;
+  inline static axisem3d::eigen::vec_ar1_CMatPP_RM sStiffSpherical_FR;
   // cardinal
-  inline static eigen::RMatXN3 sStrainSpherical_CD = eigen::RMatXN3(0, spectral::nPEM * 3);
-  inline static eigen::RMatXN3 sStrainUndulated_CD = eigen::RMatXN3(0, spectral::nPEM * 3);
-  inline static eigen::RMatXN3 sStressUndulated_CD = eigen::RMatXN3(0, spectral::nPEM * 3);
-  inline static eigen::RMatXN3 sStressSpherical_CD = eigen::RMatXN3(0, spectral::nPEM * 3);
+  inline static axisem3d::eigen::RMatXN3 sStrainSpherical_CD =
+      axisem3d::eigen::RMatXN3(0, spectral::nPEM * 3);
+  inline static axisem3d::eigen::RMatXN3 sStrainUndulated_CD =
+      axisem3d::eigen::RMatXN3(0, spectral::nPEM * 3);
+  inline static axisem3d::eigen::RMatXN3 sStressUndulated_CD =
+      axisem3d::eigen::RMatXN3(0, spectral::nPEM * 3);
+  inline static axisem3d::eigen::RMatXN3 sStressSpherical_CD =
+      axisem3d::eigen::RMatXN3(0, spectral::nPEM * 3);
 };
 
 #endif /* FluidElement_hpp */

--- a/src/core/element/PRT/PRT.hpp
+++ b/src/core/element/PRT/PRT.hpp
@@ -34,20 +34,21 @@ class PRT {
   public:
 #ifdef AXISEM3D_SAVE_MEMORY
   // 1D constructor
-  PRT(const eigen::DMatPP_RM& X0,
-      const eigen::DMatPP_RM& X1,
-      const eigen::DMatPP_RM& X2,
-      const eigen::DMatPP_RM& X3,
-      const eigen::DMatPP_RM& XJ) : m1D(true), mX0(X0), mX1(X1), mX2(X2), mX3(X3), mXJ(XJ) {
+  PRT(const axisem3d::eigen::DMatPP_RM& X0,
+      const axisem3d::eigen::DMatPP_RM& X1,
+      const axisem3d::eigen::DMatPP_RM& X2,
+      const axisem3d::eigen::DMatPP_RM& X3,
+      const axisem3d::eigen::DMatPP_RM& XJ) :
+      m1D(true), mX0(X0), mX1(X1), mX2(X2), mX3(X3), mXJ(XJ) {
     // noting
   }
 
   // 3D constructor
-  PRT(const eigen::DMatXN& X0,
-      const eigen::DMatXN& X1,
-      const eigen::DMatXN& X2,
-      const eigen::DMatXN& X3,
-      const eigen::DMatXN& XJ) : m1D(false), mX0(X0), mX1(X1), mX2(X2), mX3(X3), mXJ(XJ) {
+  PRT(const axisem3d::eigen::DMatXN& X0,
+      const axisem3d::eigen::DMatXN& X1,
+      const axisem3d::eigen::DMatXN& X2,
+      const axisem3d::eigen::DMatXN& X3,
+      const axisem3d::eigen::DMatXN& XJ) : m1D(false), mX0(X0), mX1(X1), mX2(X2), mX3(X3), mXJ(XJ) {
     // noting
   }
 
@@ -59,26 +60,30 @@ class PRT {
   }
 #else
   // 1D constructor
-  PRT(const eigen::DMatPP_RM& X0,
-      const eigen::DMatPP_RM& X1,
-      const eigen::DMatPP_RM& X2,
-      const eigen::DMatPP_RM& X3,
-      const eigen::DMatPP_RM& XJ) :
-      m1D(true), mX0(X0), mX1(X1), mX2(X2), mX3(X3), mX0_J(eigen::DMatPP_RM(X0.cwiseProduct(XJ))),
-      mX1_J(eigen::DMatPP_RM(X1.cwiseProduct(XJ))), mX2_J(eigen::DMatPP_RM(X2.cwiseProduct(XJ))),
-      mX3_J(eigen::DMatPP_RM(X3.cwiseProduct(XJ))) {
+  PRT(const axisem3d::eigen::DMatPP_RM& X0,
+      const axisem3d::eigen::DMatPP_RM& X1,
+      const axisem3d::eigen::DMatPP_RM& X2,
+      const axisem3d::eigen::DMatPP_RM& X3,
+      const axisem3d::eigen::DMatPP_RM& XJ) :
+      m1D(true), mX0(X0), mX1(X1), mX2(X2), mX3(X3),
+      mX0_J(axisem3d::eigen::DMatPP_RM(X0.cwiseProduct(XJ))),
+      mX1_J(axisem3d::eigen::DMatPP_RM(X1.cwiseProduct(XJ))),
+      mX2_J(axisem3d::eigen::DMatPP_RM(X2.cwiseProduct(XJ))),
+      mX3_J(axisem3d::eigen::DMatPP_RM(X3.cwiseProduct(XJ))) {
     // noting
   }
 
   // 3D constructor
-  PRT(const eigen::DMatXN& X0,
-      const eigen::DMatXN& X1,
-      const eigen::DMatXN& X2,
-      const eigen::DMatXN& X3,
-      const eigen::DMatXN& XJ) :
-      m1D(false), mX0(X0), mX1(X1), mX2(X2), mX3(X3), mX0_J(eigen::DMatXN(X0.cwiseProduct(XJ))),
-      mX1_J(eigen::DMatXN(X1.cwiseProduct(XJ))), mX2_J(eigen::DMatXN(X2.cwiseProduct(XJ))),
-      mX3_J(eigen::DMatXN(X3.cwiseProduct(XJ))) {
+  PRT(const axisem3d::eigen::DMatXN& X0,
+      const axisem3d::eigen::DMatXN& X1,
+      const axisem3d::eigen::DMatXN& X2,
+      const axisem3d::eigen::DMatXN& X3,
+      const axisem3d::eigen::DMatXN& XJ) :
+      m1D(false), mX0(X0), mX1(X1), mX2(X2), mX3(X3),
+      mX0_J(axisem3d::eigen::DMatXN(X0.cwiseProduct(XJ))),
+      mX1_J(axisem3d::eigen::DMatXN(X1.cwiseProduct(XJ))),
+      mX2_J(axisem3d::eigen::DMatXN(X2.cwiseProduct(XJ))),
+      mX3_J(axisem3d::eigen::DMatXN(X3.cwiseProduct(XJ))) {
     // noting
   }
 
@@ -114,8 +119,9 @@ class PRT {
   //////////////////////// Fourier space ////////////////////////
   // fluid, sph -> und
   void
-  sphericalToUndulated3_FR(
-      const eigen::vec_ar3_CMatPP_RM& sph3, eigen::vec_ar3_CMatPP_RM& und3, int nu_1) const {
+  sphericalToUndulated3_FR(const axisem3d::eigen::vec_ar3_CMatPP_RM& sph3,
+      axisem3d::eigen::vec_ar3_CMatPP_RM& und3,
+      int nu_1) const {
     for (int alpha = 0; alpha < nu_1; alpha++) {
       sphericalToUndulated3<CaseFA::_1D_FR>(sph3, und3, alpha, mX0, mX1, mX2, mX3);
     }
@@ -123,8 +129,9 @@ class PRT {
 
   // solid, sph -> und
   void
-  sphericalToUndulated6_FR(
-      const eigen::vec_ar9_CMatPP_RM& sph9, eigen::vec_ar6_CMatPP_RM& und6, int nu_1) const {
+  sphericalToUndulated6_FR(const axisem3d::eigen::vec_ar9_CMatPP_RM& sph9,
+      axisem3d::eigen::vec_ar6_CMatPP_RM& und6,
+      int nu_1) const {
     for (int alpha = 0; alpha < nu_1; alpha++) {
       sphericalToUndulated6<CaseFA::_1D_FR>(sph9, und6, alpha, mX0, mX1, mX2, mX3);
     }
@@ -132,8 +139,9 @@ class PRT {
 
   // solid, sph -> und, for curl computation (9->9)
   void
-  sphericalToUndulated9_FR(
-      const eigen::vec_ar9_CMatPP_RM& sph9, eigen::vec_ar9_CMatPP_RM& und9, int nu_1) const {
+  sphericalToUndulated9_FR(const axisem3d::eigen::vec_ar9_CMatPP_RM& sph9,
+      axisem3d::eigen::vec_ar9_CMatPP_RM& und9,
+      int nu_1) const {
     for (int alpha = 0; alpha < nu_1; alpha++) {
       sphericalToUndulated9<CaseFA::_1D_FR>(sph9, und9, alpha, mX0, mX1, mX2, mX3);
     }
@@ -141,8 +149,9 @@ class PRT {
 
   // fluid, und -> sph
   void
-  undulatedToSpherical3_FR(
-      const eigen::vec_ar3_CMatPP_RM& und3, eigen::vec_ar3_CMatPP_RM& sph3, int nu_1) const {
+  undulatedToSpherical3_FR(const axisem3d::eigen::vec_ar3_CMatPP_RM& und3,
+      axisem3d::eigen::vec_ar3_CMatPP_RM& sph3,
+      int nu_1) const {
 #ifdef AXISEM3D_SAVE_MEMORY
     computeScaledX();
 #endif
@@ -153,8 +162,9 @@ class PRT {
 
   // solid, und -> sph
   void
-  undulatedToSpherical6_FR(
-      const eigen::vec_ar6_CMatPP_RM& und6, eigen::vec_ar9_CMatPP_RM& sph9, int nu_1) const {
+  undulatedToSpherical6_FR(const axisem3d::eigen::vec_ar6_CMatPP_RM& und6,
+      axisem3d::eigen::vec_ar9_CMatPP_RM& sph9,
+      int nu_1) const {
 #ifdef AXISEM3D_SAVE_MEMORY
     computeScaledX();
 #endif
@@ -165,8 +175,9 @@ class PRT {
 
   // solid, und -> sph, no integration, for moment tensor
   void
-  undulatedToSpherical6_NoIntegration_FR(
-      const eigen::vec_ar6_CMatPP_RM& und6, eigen::vec_ar9_CMatPP_RM& sph9, int nu_1) const {
+  undulatedToSpherical6_NoIntegration_FR(const axisem3d::eigen::vec_ar6_CMatPP_RM& und6,
+      axisem3d::eigen::vec_ar9_CMatPP_RM& sph9,
+      int nu_1) const {
     for (int alpha = 0; alpha < nu_1; alpha++) {
       undulatedToSpherical6<CaseFA::_1D_FR>(und6, sph9, alpha, mX0, mX1, mX2, mX3);
     }
@@ -175,7 +186,8 @@ class PRT {
   //////////////////////// cardinal space ////////////////////////
   // fluid, sph -> und
   void
-  sphericalToUndulated3_CD(const eigen::RMatXN3& sph3, eigen::RMatXN3& und3, int nr) const {
+  sphericalToUndulated3_CD(
+      const axisem3d::eigen::RMatXN3& sph3, axisem3d::eigen::RMatXN3& und3, int nr) const {
     if (m1D) {
       sphericalToUndulated3<CaseFA::_1D_CD>(sph3, und3, nr, mX0, mX1, mX2, mX3);
     } else {
@@ -185,7 +197,8 @@ class PRT {
 
   // solid, sph -> und
   void
-  sphericalToUndulated6_CD(const eigen::RMatXN9& sph9, eigen::RMatXN6& und6, int nr) const {
+  sphericalToUndulated6_CD(
+      const axisem3d::eigen::RMatXN9& sph9, axisem3d::eigen::RMatXN6& und6, int nr) const {
     if (m1D) {
       sphericalToUndulated6<CaseFA::_1D_CD>(sph9, und6, nr, mX0, mX1, mX2, mX3);
     } else {
@@ -195,7 +208,8 @@ class PRT {
 
   // solid, sph -> und, for curl computation (9->9)
   void
-  sphericalToUndulated9_CD(const eigen::RMatXN9& sph9, eigen::RMatXN9& und9, int nr) const {
+  sphericalToUndulated9_CD(
+      const axisem3d::eigen::RMatXN9& sph9, axisem3d::eigen::RMatXN9& und9, int nr) const {
     if (m1D) {
       sphericalToUndulated9<CaseFA::_1D_CD>(sph9, und9, nr, mX0, mX1, mX2, mX3);
     } else {
@@ -205,7 +219,8 @@ class PRT {
 
   // fluid, und -> sph
   void
-  undulatedToSpherical3_CD(const eigen::RMatXN3& und3, eigen::RMatXN3& sph3, int nr) const {
+  undulatedToSpherical3_CD(
+      const axisem3d::eigen::RMatXN3& und3, axisem3d::eigen::RMatXN3& sph3, int nr) const {
 #ifdef AXISEM3D_SAVE_MEMORY
     computeScaledX();
 #endif
@@ -218,7 +233,8 @@ class PRT {
 
   // solid, und -> sph
   void
-  undulatedToSpherical6_CD(const eigen::RMatXN6& und6, eigen::RMatXN9& sph9, int nr) const {
+  undulatedToSpherical6_CD(
+      const axisem3d::eigen::RMatXN6& und6, axisem3d::eigen::RMatXN9& sph9, int nr) const {
 #ifdef AXISEM3D_SAVE_MEMORY
     computeScaledX();
 #endif
@@ -232,7 +248,7 @@ class PRT {
   // solid, und -> sph, no integration, for moment tensor
   void
   undulatedToSpherical6_NoIntegration_CD(
-      const eigen::RMatXN6& und6, eigen::RMatXN9& sph9, int nr) const {
+      const axisem3d::eigen::RMatXN6& und6, axisem3d::eigen::RMatXN9& sph9, int nr) const {
     if (m1D) {
       undulatedToSpherical6<CaseFA::_1D_CD>(und6, sph9, nr, mX0, mX1, mX2, mX3);
     } else {

--- a/src/core/element/SolidElement.cpp
+++ b/src/core/element/SolidElement.cpp
@@ -99,7 +99,7 @@ SolidElement::getPoint(int ipnt) const {
 /////////////////////////// time loop ///////////////////////////
 // collect displacement from points
 void
-SolidElement::collectDisplFromPoints(eigen::vec_ar3_CMatPP_RM& displElem) const {
+SolidElement::collectDisplFromPoints(axisem3d::eigen::vec_ar3_CMatPP_RM& displElem) const {
   for (int ipol = 0; ipol < spectral::nPED; ipol++) {
     for (int jpol = 0; jpol < spectral::nPED; jpol++) {
       mPoints[ipol * spectral::nPED + jpol]->scatterDisplToElement(displElem, mNu_1, ipol, jpol);
@@ -109,8 +109,8 @@ SolidElement::collectDisplFromPoints(eigen::vec_ar3_CMatPP_RM& displElem) const 
 
 // displacement to stiffness
 void
-SolidElement::displToStiff(
-    const eigen::vec_ar3_CMatPP_RM& displElem, eigen::vec_ar3_CMatPP_RM& stiffElem) const {
+SolidElement::displToStiff(const axisem3d::eigen::vec_ar3_CMatPP_RM& displElem,
+    axisem3d::eigen::vec_ar3_CMatPP_RM& stiffElem) const {
   if (mPRT) {
     /////////////// with PRT, strain in 3 * 3 ///////////////
     // disp to strain
@@ -184,7 +184,7 @@ SolidElement::displToStiff(
 // add stiffness to points
 // allow a derived class to change stiffElem (no const)
 void
-SolidElement::addStiffToPoints(eigen::vec_ar3_CMatPP_RM& stiffElem) const {
+SolidElement::addStiffToPoints(axisem3d::eigen::vec_ar3_CMatPP_RM& stiffElem) const {
   for (int ipol = 0; ipol < spectral::nPED; ipol++) {
     for (int jpol = 0; jpol < spectral::nPED; jpol++) {
       mPoints[ipol * spectral::nPED + jpol]->gatherStiffFromElement(stiffElem, ipol, jpol);
@@ -238,7 +238,7 @@ SolidElement::prepareForceSource() const {
 
 // add force source (force given in SPZ)
 void
-SolidElement::addForceSource(const eigen::CMatXN3& force, int nu_1_force) const {
+SolidElement::addForceSource(const axisem3d::eigen::CMatXN3& force, int nu_1_force) const {
   for (int ipnt = 0; ipnt < nPEM; ipnt++) {
     mPoints[ipnt]->addForceSource(force, nu_1_force, ipnt);
   }
@@ -257,7 +257,7 @@ SolidElement::prepareMomentSource() const {
 
 // add moment source (moment tensor given in SPZ)
 void
-SolidElement::addMomentSource(const eigen::CMatXN6& moment, int nu_1_moment) const {
+SolidElement::addMomentSource(const axisem3d::eigen::CMatXN6& moment, int nu_1_moment) const {
   // pad source with zeros if source has lower order than element
   // truncate source if source has higher order than element
   int nu_1_coexist = std::min(mNu_1, nu_1_moment);
@@ -370,7 +370,7 @@ SolidElement::prepareWavefieldOutput(
 
 // displ field
 void
-SolidElement::getDisplField(eigen::CMatXN3& displ, bool needRTZ) const {
+SolidElement::getDisplField(axisem3d::eigen::CMatXN3& displ, bool needRTZ) const {
   // collect displacement from points
   collectDisplFromPoints(sDisplSpherical_FR);
 
@@ -385,13 +385,13 @@ SolidElement::getDisplField(eigen::CMatXN3& displ, bool needRTZ) const {
 
 // nabla field
 void
-SolidElement::getNablaField(eigen::CMatXN9& nabla, bool needRTZ) const {
+SolidElement::getNablaField(axisem3d::eigen::CMatXN9& nabla, bool needRTZ) const {
   // collect displacement from points
   collectDisplFromPoints(sDisplSpherical_FR);
 
   // displ to nabla, use sStressSpherical as temp storage
-  eigen::vec_ar9_CMatPP_RM& sStrainUndulated9_FR = sStressSpherical_FR;
-  eigen::RMatXN9& sStrainUndulated9_CD = sStressSpherical_CD;
+  axisem3d::eigen::vec_ar9_CMatPP_RM& sStrainUndulated9_FR = sStressSpherical_FR;
+  axisem3d::eigen::RMatXN9& sStrainUndulated9_CD = sStressSpherical_CD;
   if (mPRT) {
     mGradQuad->computeGrad9(sDisplSpherical_FR, sStrainSpherical_FR, mNu_1);
     mTransform->transformSPZ_RTZ9(sStrainSpherical_FR, mNu_1);
@@ -418,7 +418,7 @@ SolidElement::getNablaField(eigen::CMatXN9& nabla, bool needRTZ) const {
 
 // strain field
 void
-SolidElement::getStrainField(eigen::CMatXN6& strain, bool needRTZ) const {
+SolidElement::getStrainField(axisem3d::eigen::CMatXN6& strain, bool needRTZ) const {
   // collect displacement from points
   collectDisplFromPoints(sDisplSpherical_FR);
 
@@ -463,13 +463,13 @@ SolidElement::getStrainField(eigen::CMatXN6& strain, bool needRTZ) const {
 
 // curl field
 void
-SolidElement::getCurlField(eigen::CMatXN3& curl, bool needRTZ) const {
+SolidElement::getCurlField(axisem3d::eigen::CMatXN3& curl, bool needRTZ) const {
   // collect displacement from points
   collectDisplFromPoints(sDisplSpherical_FR);
 
   // displ to nabla, use sStressSpherical as temp storage
-  eigen::vec_ar9_CMatPP_RM& sStrainUndulated9_FR = sStressSpherical_FR;
-  eigen::RMatXN9& sStrainUndulated9_CD = sStressSpherical_CD;
+  axisem3d::eigen::vec_ar9_CMatPP_RM& sStrainUndulated9_FR = sStressSpherical_FR;
+  axisem3d::eigen::RMatXN9& sStrainUndulated9_CD = sStressSpherical_CD;
   if (mPRT) {
     mGradQuad->computeGrad9(sDisplSpherical_FR, sStrainSpherical_FR, mNu_1);
     mTransform->transformSPZ_RTZ9(sStrainSpherical_FR, mNu_1);
@@ -485,7 +485,7 @@ SolidElement::getCurlField(eigen::CMatXN3& curl, bool needRTZ) const {
   }
 
   // nabla to curl, use sStiffSpherical_FR as temp storage
-  eigen::vec_ar3_CMatPP_RM& sCurlUndulated_FR = sStiffSpherical_FR;
+  axisem3d::eigen::vec_ar3_CMatPP_RM& sCurlUndulated_FR = sStiffSpherical_FR;
   for (int alpha = 0; alpha < mNu_1; alpha++) {
     sCurlUndulated_FR[alpha][0] = (sStrainUndulated9_FR[alpha][7] - sStrainUndulated9_FR[alpha][5]);
     sCurlUndulated_FR[alpha][1] = (sStrainUndulated9_FR[alpha][2] - sStrainUndulated9_FR[alpha][6]);
@@ -505,7 +505,7 @@ SolidElement::getCurlField(eigen::CMatXN3& curl, bool needRTZ) const {
 
 // stress field
 void
-SolidElement::getStressField(eigen::CMatXN6& stress, bool needRTZ) const {
+SolidElement::getStressField(axisem3d::eigen::CMatXN6& stress, bool needRTZ) const {
   // coord
   if (needRTZ && !stressInRTZ()) {
     // change to Voigt convention for strain before rotation

--- a/src/core/element/SolidElement.hpp
+++ b/src/core/element/SolidElement.hpp
@@ -60,17 +60,17 @@ class SolidElement : public Element {
   /////////////////////////// time loop ///////////////////////////
   // collect displacement from points
   virtual void
-  collectDisplFromPoints(eigen::vec_ar3_CMatPP_RM& displElem) const;
+  collectDisplFromPoints(axisem3d::eigen::vec_ar3_CMatPP_RM& displElem) const;
 
   // displacement to stiffness
   void
-  displToStiff(
-      const eigen::vec_ar3_CMatPP_RM& displElem, eigen::vec_ar3_CMatPP_RM& stiffElem) const;
+  displToStiff(const axisem3d::eigen::vec_ar3_CMatPP_RM& displElem,
+      axisem3d::eigen::vec_ar3_CMatPP_RM& stiffElem) const;
 
   // add stiffness to points
   // allow a derived class to change stiffElem (no const)
   virtual void
-  addStiffToPoints(eigen::vec_ar3_CMatPP_RM& stiffElem) const;
+  addStiffToPoints(axisem3d::eigen::vec_ar3_CMatPP_RM& stiffElem) const;
 
   // compute stiffness term
   void
@@ -87,7 +87,7 @@ class SolidElement : public Element {
 
   // add force source (force given in SPZ)
   void
-  addForceSource(const eigen::CMatXN3& force, int nu_1_force) const;
+  addForceSource(const axisem3d::eigen::CMatXN3& force, int nu_1_force) const;
 
   // prepare moment source (moment tensor given in SPZ)
   void
@@ -95,7 +95,7 @@ class SolidElement : public Element {
 
   // add moment source (moment tensor given in SPZ)
   void
-  addMomentSource(const eigen::CMatXN6& moment, int nu_1_moment) const;
+  addMomentSource(const axisem3d::eigen::CMatXN6& moment, int nu_1_moment) const;
 
   /////////////////////////// wavefield output ///////////////////////////
   // prepare wavefield output
@@ -104,53 +104,53 @@ class SolidElement : public Element {
 
   // displ field
   void
-  getDisplField(eigen::CMatXN3& displ) const {
+  getDisplField(axisem3d::eigen::CMatXN3& displ) const {
     getDisplField(displ, displInRTZ());
   }
 
   // displ field
   void
-  getDisplField(eigen::CMatXN3& displ, bool needRTZ) const;
+  getDisplField(axisem3d::eigen::CMatXN3& displ, bool needRTZ) const;
 
   // nabla field
   void
-  getNablaField(eigen::CMatXN9& nabla) const {
+  getNablaField(axisem3d::eigen::CMatXN9& nabla) const {
     getNablaField(nabla, nablaInRTZ());
   }
 
   // nabla field
   void
-  getNablaField(eigen::CMatXN9& nabla, bool needRTZ) const;
+  getNablaField(axisem3d::eigen::CMatXN9& nabla, bool needRTZ) const;
 
   // strain field
   void
-  getStrainField(eigen::CMatXN6& strain) const {
+  getStrainField(axisem3d::eigen::CMatXN6& strain) const {
     getStrainField(strain, strainInRTZ());
   }
 
   // strain field
   void
-  getStrainField(eigen::CMatXN6& strain, bool needRTZ) const;
+  getStrainField(axisem3d::eigen::CMatXN6& strain, bool needRTZ) const;
 
   // curl field
   void
-  getCurlField(eigen::CMatXN3& curl) const {
+  getCurlField(axisem3d::eigen::CMatXN3& curl) const {
     getCurlField(curl, curlInRTZ());
   }
 
   // curl field
   void
-  getCurlField(eigen::CMatXN3& curl, bool needRTZ) const;
+  getCurlField(axisem3d::eigen::CMatXN3& curl, bool needRTZ) const;
 
   // stress field
   void
-  getStressField(eigen::CMatXN6& stress) const {
+  getStressField(axisem3d::eigen::CMatXN6& stress) const {
     getStressField(stress, stressInRTZ());
   }
 
   // stress field
   void
-  getStressField(eigen::CMatXN6& stress, bool needRTZ) const;
+  getStressField(axisem3d::eigen::CMatXN6& stress, bool needRTZ) const;
 
   // displ crd
   inline bool
@@ -194,8 +194,8 @@ class SolidElement : public Element {
 
   // stress buffer
   // stress cannot be recomputed with attenuation
-  const std::unique_ptr<eigen::vec_ar6_CMatPP_RM> mStressBuffer =
-      std::make_unique<eigen::vec_ar6_CMatPP_RM>();
+  const std::unique_ptr<axisem3d::eigen::vec_ar6_CMatPP_RM> mStressBuffer =
+      std::make_unique<axisem3d::eigen::vec_ar6_CMatPP_RM>();
 
   ////////////////////////////////////////
   //////////////// static ////////////////
@@ -221,17 +221,21 @@ class SolidElement : public Element {
 
   // workspace
   // Fourier
-  inline static eigen::vec_ar3_CMatPP_RM sDisplSpherical_FR;
-  inline static eigen::vec_ar9_CMatPP_RM sStrainSpherical_FR;
-  inline static eigen::vec_ar6_CMatPP_RM sStrainUndulated_FR;
-  inline static eigen::vec_ar6_CMatPP_RM sStressUndulated_FR;
-  inline static eigen::vec_ar9_CMatPP_RM sStressSpherical_FR;
-  inline static eigen::vec_ar3_CMatPP_RM sStiffSpherical_FR;
+  inline static axisem3d::eigen::vec_ar3_CMatPP_RM sDisplSpherical_FR;
+  inline static axisem3d::eigen::vec_ar9_CMatPP_RM sStrainSpherical_FR;
+  inline static axisem3d::eigen::vec_ar6_CMatPP_RM sStrainUndulated_FR;
+  inline static axisem3d::eigen::vec_ar6_CMatPP_RM sStressUndulated_FR;
+  inline static axisem3d::eigen::vec_ar9_CMatPP_RM sStressSpherical_FR;
+  inline static axisem3d::eigen::vec_ar3_CMatPP_RM sStiffSpherical_FR;
   // cardinal
-  inline static eigen::RMatXN9 sStrainSpherical_CD = eigen::RMatXN9(0, spectral::nPEM * 9);
-  inline static eigen::RMatXN6 sStrainUndulated_CD = eigen::RMatXN6(0, spectral::nPEM * 6);
-  inline static eigen::RMatXN6 sStressUndulated_CD = eigen::RMatXN6(0, spectral::nPEM * 6);
-  inline static eigen::RMatXN9 sStressSpherical_CD = eigen::RMatXN9(0, spectral::nPEM * 9);
+  inline static axisem3d::eigen::RMatXN9 sStrainSpherical_CD =
+      axisem3d::eigen::RMatXN9(0, spectral::nPEM * 9);
+  inline static axisem3d::eigen::RMatXN6 sStrainUndulated_CD =
+      axisem3d::eigen::RMatXN6(0, spectral::nPEM * 6);
+  inline static axisem3d::eigen::RMatXN6 sStressUndulated_CD =
+      axisem3d::eigen::RMatXN6(0, spectral::nPEM * 6);
+  inline static axisem3d::eigen::RMatXN9 sStressSpherical_CD =
+      axisem3d::eigen::RMatXN9(0, spectral::nPEM * 9);
 };
 
 #endif /* SolidElement_hpp */

--- a/src/core/element/common/eigen_element.hpp
+++ b/src/core/element/common/eigen_element.hpp
@@ -16,7 +16,7 @@
 #include "numerical.hpp"
 #include "spectral.hpp"
 
-namespace eigen {
+namespace axisem3d::eigen {
   using numerical::ComplexR;
   using numerical::Real;
   using spectral::nPEM;
@@ -49,6 +49,6 @@ namespace eigen {
 
   // properties
   typedef Eigen::Matrix<double, Eigen::Dynamic, nPEM> DMatXN;
-} // namespace eigen
+} // namespace axisem3d::eigen
 
 #endif /* eigen_element_hpp */

--- a/src/core/element/crd/CoordTransform.hpp
+++ b/src/core/element/crd/CoordTransform.hpp
@@ -22,27 +22,27 @@ class CoordTransform {
 
   // (s,phi,z) -> (R,T,Z)
   virtual void
-  transformSPZ_RTZ3(eigen::vec_ar3_CMatPP_RM& ui, int nu_1) const = 0;
+  transformSPZ_RTZ3(axisem3d::eigen::vec_ar3_CMatPP_RM& ui, int nu_1) const = 0;
 
   // (R,T,Z) -> (s,phi,z)
   virtual void
-  transformRTZ_SPZ3(eigen::vec_ar3_CMatPP_RM& ui, int nu_1) const = 0;
+  transformRTZ_SPZ3(axisem3d::eigen::vec_ar3_CMatPP_RM& ui, int nu_1) const = 0;
 
   // (s,phi,z) -> (R,T,Z) for nabla
   virtual void
-  transformSPZ_RTZ9(eigen::vec_ar9_CMatPP_RM& nij, int nu_1) const = 0;
+  transformSPZ_RTZ9(axisem3d::eigen::vec_ar9_CMatPP_RM& nij, int nu_1) const = 0;
 
   // (R,T,Z) -> (s,phi,z) for nabla
   virtual void
-  transformRTZ_SPZ9(eigen::vec_ar9_CMatPP_RM& nij, int nu_1) const = 0;
+  transformRTZ_SPZ9(axisem3d::eigen::vec_ar9_CMatPP_RM& nij, int nu_1) const = 0;
 
   // (s,phi,z) -> (R,T,Z) for Voigt
   virtual void
-  transformSPZ_RTZ6(eigen::vec_ar6_CMatPP_RM& eij, int nu_1) const = 0;
+  transformSPZ_RTZ6(axisem3d::eigen::vec_ar6_CMatPP_RM& eij, int nu_1) const = 0;
 
   // (R,T,Z) -> (s,phi,z) for Voigt
   virtual void
-  transformRTZ_SPZ6(eigen::vec_ar6_CMatPP_RM& sij, int nu_1) const = 0;
+  transformRTZ_SPZ6(axisem3d::eigen::vec_ar6_CMatPP_RM& sij, int nu_1) const = 0;
 };
 
 #endif /* CoordTransform_hpp */

--- a/src/core/element/crd/CoordTransformCartesian.hpp
+++ b/src/core/element/crd/CoordTransformCartesian.hpp
@@ -20,37 +20,37 @@ class CoordTransformCartesian : public CoordTransform {
   public:
   // (s,phi,z) -> (R,T,Z)
   void
-  transformSPZ_RTZ3(eigen::vec_ar3_CMatPP_RM& ui, int nu_1) const {
+  transformSPZ_RTZ3(axisem3d::eigen::vec_ar3_CMatPP_RM& ui, int nu_1) const {
     // nothing
   }
 
   // (R,T,Z) -> (s,phi,z)
   void
-  transformRTZ_SPZ3(eigen::vec_ar3_CMatPP_RM& ui, int nu_1) const {
+  transformRTZ_SPZ3(axisem3d::eigen::vec_ar3_CMatPP_RM& ui, int nu_1) const {
     // nothing
   }
 
   // (s,phi,z) -> (R,T,Z) for nabla
   void
-  transformSPZ_RTZ9(eigen::vec_ar9_CMatPP_RM& nij, int nu_1) const {
+  transformSPZ_RTZ9(axisem3d::eigen::vec_ar9_CMatPP_RM& nij, int nu_1) const {
     // nothing
   }
 
   // (R,T,Z) -> (s,phi,z) for nabla
   void
-  transformRTZ_SPZ9(eigen::vec_ar9_CMatPP_RM& nij, int nu_1) const {
+  transformRTZ_SPZ9(axisem3d::eigen::vec_ar9_CMatPP_RM& nij, int nu_1) const {
     // nothing
   }
 
   // (s,phi,z) -> (R,T,Z) for Voigt
   void
-  transformSPZ_RTZ6(eigen::vec_ar6_CMatPP_RM& eij, int nu_1) const {
+  transformSPZ_RTZ6(axisem3d::eigen::vec_ar6_CMatPP_RM& eij, int nu_1) const {
     // nothing
   }
 
   // (R,T,Z) -> (s,phi,z) for Voigt
   void
-  transformRTZ_SPZ6(eigen::vec_ar6_CMatPP_RM& sij, int nu_1) const {
+  transformRTZ_SPZ6(axisem3d::eigen::vec_ar6_CMatPP_RM& sij, int nu_1) const {
     // nothing
   }
 };

--- a/src/core/element/crd/CoordTransformSpherical.hpp
+++ b/src/core/element/crd/CoordTransformSpherical.hpp
@@ -36,12 +36,13 @@ class CoordTransformSpherical : public CoordTransform {
   public:
 #ifdef AXISEM3D_SAVE_MEMORY
   // constructor
-  CoordTransformSpherical(const eigen::DMatPP_RM& theta) : mTheta(theta.cast<numerical::Real>()) {
+  CoordTransformSpherical(const axisem3d::eigen::DMatPP_RM& theta) :
+      mTheta(theta.cast<numerical::Real>()) {
     // nothing
   }
 #else
   // constructor
-  CoordTransformSpherical(const eigen::DMatPP_RM& theta) :
+  CoordTransformSpherical(const axisem3d::eigen::DMatPP_RM& theta) :
       mSin1t(theta.array().sin().cast<numerical::Real>()),
       mCos1t(theta.array().cos().cast<numerical::Real>()),
       mSin2t((2. * theta).array().sin().cast<numerical::Real>()),
@@ -52,14 +53,14 @@ class CoordTransformSpherical : public CoordTransform {
 
   // (s,phi,z) -> (R,T,Z)
   void
-  transformSPZ_RTZ3(eigen::vec_ar3_CMatPP_RM& ui, int nu_1) const {
+  transformSPZ_RTZ3(axisem3d::eigen::vec_ar3_CMatPP_RM& ui, int nu_1) const {
 #ifdef AXISEM3D_SAVE_MEMORY
     // compute sin(theta)
     computeSinOneTheta();
 #endif
     for (int alpha = 0; alpha < nu_1; alpha++) {
       // copy u0
-      eigen::CMatPP_RM& ui_alpha__0_ = sTemp0;
+      axisem3d::eigen::CMatPP_RM& ui_alpha__0_ = sTemp0;
       ui_alpha__0_ = ui[alpha][0];
 
       // rtz0 = spz0 * cos(t) - spz2 * sin(t)
@@ -75,14 +76,14 @@ class CoordTransformSpherical : public CoordTransform {
 
   // (R,T,Z) -> (s,phi,z)
   void
-  transformRTZ_SPZ3(eigen::vec_ar3_CMatPP_RM& ui, int nu_1) const {
+  transformRTZ_SPZ3(axisem3d::eigen::vec_ar3_CMatPP_RM& ui, int nu_1) const {
 #ifdef AXISEM3D_SAVE_MEMORY
     // compute sin(theta)
     computeSinOneTheta();
 #endif
     for (int alpha = 0; alpha < nu_1; alpha++) {
       // copy u0
-      eigen::CMatPP_RM& ui_alpha__0_ = sTemp0;
+      axisem3d::eigen::CMatPP_RM& ui_alpha__0_ = sTemp0;
       ui_alpha__0_ = ui[alpha][0];
 
       // spz0 = rtz0 * cos(t) + rtz2 * sin(t)
@@ -98,17 +99,17 @@ class CoordTransformSpherical : public CoordTransform {
 
   // (s,phi,z) -> (R,T,Z) for nabla
   void
-  transformSPZ_RTZ9(eigen::vec_ar9_CMatPP_RM& nij, int nu_1) const {
+  transformSPZ_RTZ9(axisem3d::eigen::vec_ar9_CMatPP_RM& nij, int nu_1) const {
 #ifdef AXISEM3D_SAVE_MEMORY
     // compute sin(theta)
     computeSinOneTwoTheta();
 #endif
     for (int alpha = 0; alpha < nu_1; alpha++) {
       // 2 * theta terms
-      eigen::CMatPP_RM& s08 = sTemp0;
-      eigen::CMatPP_RM& d08 = sTemp1;
-      eigen::CMatPP_RM& s26 = sTemp2;
-      eigen::CMatPP_RM& d26 = sTemp3;
+      axisem3d::eigen::CMatPP_RM& s08 = sTemp0;
+      axisem3d::eigen::CMatPP_RM& d08 = sTemp1;
+      axisem3d::eigen::CMatPP_RM& s26 = sTemp2;
+      axisem3d::eigen::CMatPP_RM& d26 = sTemp3;
       s08 = nij[alpha][0] + nij[alpha][8];
       d08 = nij[alpha][0] - nij[alpha][8];
       s26 = nij[alpha][2] + nij[alpha][6];
@@ -119,11 +120,11 @@ class CoordTransformSpherical : public CoordTransform {
       nij[alpha][8] = s08 - nij[alpha][0];
 
       // 1 * theta terms
-      eigen::CMatPP_RM& nij_alpha__1_ = sTemp0;
+      axisem3d::eigen::CMatPP_RM& nij_alpha__1_ = sTemp0;
       nij_alpha__1_ = nij[alpha][1];
       nij[alpha][1] = (nij_alpha__1_.cwiseProduct(xCos1t) - nij[alpha][7].cwiseProduct(xSin1t));
       nij[alpha][7] = (nij[alpha][7].cwiseProduct(xCos1t) + nij_alpha__1_.cwiseProduct(xSin1t));
-      eigen::CMatPP_RM& nij_alpha__3_ = sTemp0;
+      axisem3d::eigen::CMatPP_RM& nij_alpha__3_ = sTemp0;
       nij_alpha__3_ = nij[alpha][3];
       nij[alpha][3] = (nij_alpha__3_.cwiseProduct(xCos1t) - nij[alpha][5].cwiseProduct(xSin1t));
       nij[alpha][5] = (nij[alpha][5].cwiseProduct(xCos1t) + nij_alpha__3_.cwiseProduct(xSin1t));
@@ -135,17 +136,17 @@ class CoordTransformSpherical : public CoordTransform {
 
   // (R,T,Z) -> (s,phi,z) for nabla
   void
-  transformRTZ_SPZ9(eigen::vec_ar9_CMatPP_RM& nij, int nu_1) const {
+  transformRTZ_SPZ9(axisem3d::eigen::vec_ar9_CMatPP_RM& nij, int nu_1) const {
 #ifdef AXISEM3D_SAVE_MEMORY
     // compute sin(theta)
     computeSinOneTwoTheta();
 #endif
     for (int alpha = 0; alpha < nu_1; alpha++) {
       // 2 * theta terms
-      eigen::CMatPP_RM& s08 = sTemp0;
-      eigen::CMatPP_RM& d08 = sTemp1;
-      eigen::CMatPP_RM& s26 = sTemp2;
-      eigen::CMatPP_RM& d26 = sTemp3;
+      axisem3d::eigen::CMatPP_RM& s08 = sTemp0;
+      axisem3d::eigen::CMatPP_RM& d08 = sTemp1;
+      axisem3d::eigen::CMatPP_RM& s26 = sTemp2;
+      axisem3d::eigen::CMatPP_RM& d26 = sTemp3;
       s08 = nij[alpha][0] + nij[alpha][8];
       d08 = nij[alpha][0] - nij[alpha][8];
       s26 = nij[alpha][2] + nij[alpha][6];
@@ -156,11 +157,11 @@ class CoordTransformSpherical : public CoordTransform {
       nij[alpha][8] = s08 - nij[alpha][0];
 
       // 1 * theta terms
-      eigen::CMatPP_RM& nij_alpha__1_ = sTemp0;
+      axisem3d::eigen::CMatPP_RM& nij_alpha__1_ = sTemp0;
       nij_alpha__1_ = nij[alpha][1];
       nij[alpha][1] = (nij_alpha__1_.cwiseProduct(xCos1t) + nij[alpha][7].cwiseProduct(xSin1t));
       nij[alpha][7] = (nij[alpha][7].cwiseProduct(xCos1t) - nij_alpha__1_.cwiseProduct(xSin1t));
-      eigen::CMatPP_RM& nij_alpha__3_ = sTemp0;
+      axisem3d::eigen::CMatPP_RM& nij_alpha__3_ = sTemp0;
       nij_alpha__3_ = nij[alpha][3];
       nij[alpha][3] = (nij_alpha__3_.cwiseProduct(xCos1t) + nij[alpha][5].cwiseProduct(xSin1t));
       nij[alpha][5] = (nij[alpha][5].cwiseProduct(xCos1t) - nij_alpha__3_.cwiseProduct(xSin1t));
@@ -172,15 +173,15 @@ class CoordTransformSpherical : public CoordTransform {
 
   // (s,phi,z) -> (R,T,Z) for Voigt
   void
-  transformSPZ_RTZ6(eigen::vec_ar6_CMatPP_RM& eij, int nu_1) const {
+  transformSPZ_RTZ6(axisem3d::eigen::vec_ar6_CMatPP_RM& eij, int nu_1) const {
 #ifdef AXISEM3D_SAVE_MEMORY
     // compute sin(theta)
     computeSinOneTwoTheta();
 #endif
     for (int alpha = 0; alpha < nu_1; alpha++) {
       // 2 * theta terms
-      eigen::CMatPP_RM& s02 = sTemp0;
-      eigen::CMatPP_RM& d02 = sTemp1;
+      axisem3d::eigen::CMatPP_RM& s02 = sTemp0;
+      axisem3d::eigen::CMatPP_RM& d02 = sTemp1;
       s02 = eij[alpha][0] + eij[alpha][2];
       d02 = eij[alpha][0] - eij[alpha][2];
       eij[alpha][0] = (s02 + d02.cwiseProduct(xCos2t) - eij[alpha][4].cwiseProduct(xSin2t)) * half;
@@ -188,7 +189,7 @@ class CoordTransformSpherical : public CoordTransform {
       eij[alpha][4] = (eij[alpha][4].cwiseProduct(xCos2t) + d02.cwiseProduct(xSin2t));
 
       // 1 * theta terms
-      eigen::CMatPP_RM& nij_alpha__3_ = sTemp0;
+      axisem3d::eigen::CMatPP_RM& nij_alpha__3_ = sTemp0;
       nij_alpha__3_ = eij[alpha][3];
       eij[alpha][3] = (nij_alpha__3_.cwiseProduct(xCos1t) + eij[alpha][5].cwiseProduct(xSin1t));
       eij[alpha][5] = (eij[alpha][5].cwiseProduct(xCos1t) - nij_alpha__3_.cwiseProduct(xSin1t));
@@ -200,15 +201,15 @@ class CoordTransformSpherical : public CoordTransform {
 
   // (R,T,Z) -> (s,phi,z) for Voigt
   void
-  transformRTZ_SPZ6(eigen::vec_ar6_CMatPP_RM& sij, int nu_1) const {
+  transformRTZ_SPZ6(axisem3d::eigen::vec_ar6_CMatPP_RM& sij, int nu_1) const {
 #ifdef AXISEM3D_SAVE_MEMORY
     // compute sin(theta)
     computeSinOneTwoTheta();
 #endif
     for (int alpha = 0; alpha < nu_1; alpha++) {
       // 2 * theta terms
-      eigen::CMatPP_RM& s02 = sTemp0;
-      eigen::CMatPP_RM& d02 = sTemp1;
+      axisem3d::eigen::CMatPP_RM& s02 = sTemp0;
+      axisem3d::eigen::CMatPP_RM& d02 = sTemp1;
       s02 = sij[alpha][0] + sij[alpha][2];
       d02 = sij[alpha][0] - sij[alpha][2];
       sij[alpha][0] =
@@ -217,7 +218,7 @@ class CoordTransformSpherical : public CoordTransform {
       sij[alpha][4] = (sij[alpha][4].cwiseProduct(xCos2t) - d02.cwiseProduct(xSin2t) * half);
 
       // 1 * theta terms
-      eigen::CMatPP_RM& nij_alpha__3_ = sTemp0;
+      axisem3d::eigen::CMatPP_RM& nij_alpha__3_ = sTemp0;
       nij_alpha__3_ = sij[alpha][3];
       sij[alpha][3] = (nij_alpha__3_.cwiseProduct(xCos1t) - sij[alpha][5].cwiseProduct(xSin1t));
       sij[alpha][5] = (sij[alpha][5].cwiseProduct(xCos1t) + nij_alpha__3_.cwiseProduct(xSin1t));
@@ -230,10 +231,10 @@ class CoordTransformSpherical : public CoordTransform {
   private:
 #ifdef AXISEM3D_SAVE_MEMORY
   // theta
-  const eigen::RMatPP_RM mTheta;
+  const axisem3d::eigen::RMatPP_RM mTheta;
 
   // sin(theta)
-  inline static eigen::RMatPP_RM sSin1t, sCos1t, sSin2t, sCos2t;
+  inline static axisem3d::eigen::RMatPP_RM sSin1t, sCos1t, sSin2t, sCos2t;
 
   // compute sin(theta) on the fly
   void
@@ -251,7 +252,7 @@ class CoordTransformSpherical : public CoordTransform {
   }
 #else
   // sin(theta)
-  const eigen::RMatPP_RM mSin1t, mCos1t, mSin2t, mCos2t;
+  const axisem3d::eigen::RMatPP_RM mSin1t, mCos1t, mSin2t, mCos2t;
 #endif
 
   ////////////////////////////////////////
@@ -260,7 +261,7 @@ class CoordTransformSpherical : public CoordTransform {
 
   private:
   // workspace
-  inline static eigen::CMatPP_RM sTemp0, sTemp1, sTemp2, sTemp3;
+  inline static axisem3d::eigen::CMatPP_RM sTemp0, sTemp1, sTemp2, sTemp3;
 };
 
 #endif /* CoordTransformSpherical_hpp */

--- a/src/core/element/grad/GradientQuadrature.hpp
+++ b/src/core/element/grad/GradientQuadrature.hpp
@@ -95,13 +95,13 @@ template <typename floatT> class GradientQuadrature {
   public:
 #ifdef AXISEM3D_SAVE_MEMORY
   // constructor
-  GradientQuadrature(const eigen::DMatPP_RM& dsdxii,
-      const eigen::DMatPP_RM& dsdeta,
-      const eigen::DMatPP_RM& dzdxii,
-      const eigen::DMatPP_RM& dzdeta,
-      const eigen::DMatPP_RM& _1ovrS,
+  GradientQuadrature(const axisem3d::eigen::DMatPP_RM& dsdxii,
+      const axisem3d::eigen::DMatPP_RM& dsdeta,
+      const axisem3d::eigen::DMatPP_RM& dzdxii,
+      const axisem3d::eigen::DMatPP_RM& dzdeta,
+      const axisem3d::eigen::DMatPP_RM& _1ovrS,
       bool axial,
-      const eigen::DMatPP_RM& integralFactor) :
+      const axisem3d::eigen::DMatPP_RM& integralFactor) :
       mDsDxii(dsdxii.cast<floatT>()), mDsDeta(dsdeta.cast<floatT>()),
       mDzDxii(dzdxii.cast<floatT>()), mDzDeta(dzdeta.cast<floatT>()),
       m1overS(_1ovrS.cast<floatT>()), mAxial(axial),
@@ -118,13 +118,13 @@ template <typename floatT> class GradientQuadrature {
   }
 #else
   // constructor
-  GradientQuadrature(const eigen::DMatPP_RM& dsdxii,
-      const eigen::DMatPP_RM& dsdeta,
-      const eigen::DMatPP_RM& dzdxii,
-      const eigen::DMatPP_RM& dzdeta,
-      const eigen::DMatPP_RM& _1ovrS,
+  GradientQuadrature(const axisem3d::eigen::DMatPP_RM& dsdxii,
+      const axisem3d::eigen::DMatPP_RM& dsdeta,
+      const axisem3d::eigen::DMatPP_RM& dzdxii,
+      const axisem3d::eigen::DMatPP_RM& dzdeta,
+      const axisem3d::eigen::DMatPP_RM& _1ovrS,
       bool axial,
-      const eigen::DMatPP_RM& integralFactor) :
+      const axisem3d::eigen::DMatPP_RM& integralFactor) :
       mDsDxii(dsdxii.cast<floatT>()), mDsDeta(dsdeta.cast<floatT>()),
       mDzDxii(dzdxii.cast<floatT>()), mDzDeta(dzdeta.cast<floatT>()),
       m1overS(_1ovrS.cast<floatT>()), mAxial(axial),
@@ -483,7 +483,7 @@ template <typename floatT> class GradientQuadrature {
   public:
   // set G Mat
   static void
-  setGMat(const eigen::DMatPP_RM& G_GLL, const eigen::DMatPP_RM& G_GLJ) {
+  setGMat(const axisem3d::eigen::DMatPP_RM& G_GLL, const axisem3d::eigen::DMatPP_RM& G_GLJ) {
     sG_GLL = G_GLL.cast<floatT>();
     sG_GLJ = G_GLJ.cast<floatT>();
     sGT_GLL = G_GLL.transpose().cast<floatT>();

--- a/src/core/element/material/acoustic/Acoustic.hpp
+++ b/src/core/element/material/acoustic/Acoustic.hpp
@@ -18,12 +18,12 @@
 class Acoustic {
   public:
   // 1D constructor
-  Acoustic(const eigen::DMatPP_RM& K) : m1D(true), mK(K) {
+  Acoustic(const axisem3d::eigen::DMatPP_RM& K) : m1D(true), mK(K) {
     // nothing
   }
 
   // 3D constructor
-  Acoustic(const eigen::DMatXN& K) : m1D(false), mK(K) {
+  Acoustic(const axisem3d::eigen::DMatXN& K) : m1D(false), mK(K) {
     // nothing
   }
 
@@ -48,8 +48,9 @@ class Acoustic {
   ///////////////////////// strain to stress /////////////////////////
   // strain => stress in Fourier space
   void
-  strainToStress_FR(
-      const eigen::vec_ar3_CMatPP_RM& strain, eigen::vec_ar3_CMatPP_RM& stress, int nu_1) const {
+  strainToStress_FR(const axisem3d::eigen::vec_ar3_CMatPP_RM& strain,
+      axisem3d::eigen::vec_ar3_CMatPP_RM& stress,
+      int nu_1) const {
     for (int alpha = 0; alpha < nu_1; alpha++) {
       strainToStress<CaseFA::_1D_FR>(strain, stress, alpha, mK);
     }
@@ -57,7 +58,8 @@ class Acoustic {
 
   // strain => stress in cardinal space
   void
-  strainToStress_CD(const eigen::RMatXN3& strain, eigen::RMatXN3& stress, int nr) const {
+  strainToStress_CD(
+      const axisem3d::eigen::RMatXN3& strain, axisem3d::eigen::RMatXN3& stress, int nr) const {
     if (m1D) {
       strainToStress<CaseFA::_1D_CD>(strain, stress, nr, mK);
     } else {

--- a/src/core/element/material/elastic/Elastic.hpp
+++ b/src/core/element/material/elastic/Elastic.hpp
@@ -65,19 +65,22 @@ class Elastic {
 
   // strain => stress in Fourier space
   virtual void
-  strainToStress_FR(
-      const eigen::vec_ar6_CMatPP_RM& strain, eigen::vec_ar6_CMatPP_RM& stress, int nu_1) const = 0;
+  strainToStress_FR(const axisem3d::eigen::vec_ar6_CMatPP_RM& strain,
+      axisem3d::eigen::vec_ar6_CMatPP_RM& stress,
+      int nu_1) const = 0;
 
   // strain => stress in cardinal space
   virtual void
-  strainToStress_CD(const eigen::RMatXN6& strain, eigen::RMatXN6& stress, int nr) const = 0;
+  strainToStress_CD(
+      const axisem3d::eigen::RMatXN6& strain, axisem3d::eigen::RMatXN6& stress, int nr) const = 0;
 
   ///////////////////////// attenuation /////////////////////////
   protected:
   // attenuation in Fourier space
   void
-  applyAttenuation(
-      const eigen::vec_ar6_CMatPP_RM& strain, eigen::vec_ar6_CMatPP_RM& stress, int nu_1) const {
+  applyAttenuation(const axisem3d::eigen::vec_ar6_CMatPP_RM& strain,
+      axisem3d::eigen::vec_ar6_CMatPP_RM& stress,
+      int nu_1) const {
     if (mAttenuation) {
       mAttenuation->apply(strain, stress, nu_1);
     }
@@ -85,7 +88,8 @@ class Elastic {
 
   // attenuation in cardinal space
   void
-  applyAttenuation(const eigen::RMatXN6& strain, eigen::RMatXN6& stress, int nr) const {
+  applyAttenuation(
+      const axisem3d::eigen::RMatXN6& strain, axisem3d::eigen::RMatXN6& stress, int nr) const {
     if (mAttenuation) {
       mAttenuation->apply(strain, stress, nr);
     }

--- a/src/core/element/material/elastic/anisotropy/Anisotropic.hpp
+++ b/src/core/element/material/elastic/anisotropy/Anisotropic.hpp
@@ -19,32 +19,32 @@ class Anisotropic : public Elastic {
   // 1D constructor
   Anisotropic(std::unique_ptr<Attenuation>& attenuation,
       // C1
-      const eigen::DMatPP_RM& C11,
-      const eigen::DMatPP_RM& C12,
-      const eigen::DMatPP_RM& C13,
-      const eigen::DMatPP_RM& C14,
-      const eigen::DMatPP_RM& C15,
-      const eigen::DMatPP_RM& C16,
+      const axisem3d::eigen::DMatPP_RM& C11,
+      const axisem3d::eigen::DMatPP_RM& C12,
+      const axisem3d::eigen::DMatPP_RM& C13,
+      const axisem3d::eigen::DMatPP_RM& C14,
+      const axisem3d::eigen::DMatPP_RM& C15,
+      const axisem3d::eigen::DMatPP_RM& C16,
       // C2
-      const eigen::DMatPP_RM& C22,
-      const eigen::DMatPP_RM& C23,
-      const eigen::DMatPP_RM& C24,
-      const eigen::DMatPP_RM& C25,
-      const eigen::DMatPP_RM& C26,
+      const axisem3d::eigen::DMatPP_RM& C22,
+      const axisem3d::eigen::DMatPP_RM& C23,
+      const axisem3d::eigen::DMatPP_RM& C24,
+      const axisem3d::eigen::DMatPP_RM& C25,
+      const axisem3d::eigen::DMatPP_RM& C26,
       // C3
-      const eigen::DMatPP_RM& C33,
-      const eigen::DMatPP_RM& C34,
-      const eigen::DMatPP_RM& C35,
-      const eigen::DMatPP_RM& C36,
+      const axisem3d::eigen::DMatPP_RM& C33,
+      const axisem3d::eigen::DMatPP_RM& C34,
+      const axisem3d::eigen::DMatPP_RM& C35,
+      const axisem3d::eigen::DMatPP_RM& C36,
       // C4
-      const eigen::DMatPP_RM& C44,
-      const eigen::DMatPP_RM& C45,
-      const eigen::DMatPP_RM& C46,
+      const axisem3d::eigen::DMatPP_RM& C44,
+      const axisem3d::eigen::DMatPP_RM& C45,
+      const axisem3d::eigen::DMatPP_RM& C46,
       // C5
-      const eigen::DMatPP_RM& C55,
-      const eigen::DMatPP_RM& C56,
+      const axisem3d::eigen::DMatPP_RM& C55,
+      const axisem3d::eigen::DMatPP_RM& C56,
       // C6
-      const eigen::DMatPP_RM& C66) :
+      const axisem3d::eigen::DMatPP_RM& C66) :
       Elastic(true, attenuation), mC11(C11), mC12(C12), mC13(C13), mC14(C14), mC15(C15), mC16(C16),
       mC22(C22), mC23(C23), mC24(C24), mC25(C25), mC26(C26), mC33(C33), mC34(C34), mC35(C35),
       mC36(C36), mC44(C44), mC45(C45), mC46(C46), mC55(C55), mC56(C56), mC66(C66) {
@@ -54,32 +54,32 @@ class Anisotropic : public Elastic {
   // 3D constructor
   Anisotropic(std::unique_ptr<Attenuation>& attenuation,
       // C1
-      const eigen::DMatXN& C11,
-      const eigen::DMatXN& C12,
-      const eigen::DMatXN& C13,
-      const eigen::DMatXN& C14,
-      const eigen::DMatXN& C15,
-      const eigen::DMatXN& C16,
+      const axisem3d::eigen::DMatXN& C11,
+      const axisem3d::eigen::DMatXN& C12,
+      const axisem3d::eigen::DMatXN& C13,
+      const axisem3d::eigen::DMatXN& C14,
+      const axisem3d::eigen::DMatXN& C15,
+      const axisem3d::eigen::DMatXN& C16,
       // C2
-      const eigen::DMatXN& C22,
-      const eigen::DMatXN& C23,
-      const eigen::DMatXN& C24,
-      const eigen::DMatXN& C25,
-      const eigen::DMatXN& C26,
+      const axisem3d::eigen::DMatXN& C22,
+      const axisem3d::eigen::DMatXN& C23,
+      const axisem3d::eigen::DMatXN& C24,
+      const axisem3d::eigen::DMatXN& C25,
+      const axisem3d::eigen::DMatXN& C26,
       // C3
-      const eigen::DMatXN& C33,
-      const eigen::DMatXN& C34,
-      const eigen::DMatXN& C35,
-      const eigen::DMatXN& C36,
+      const axisem3d::eigen::DMatXN& C33,
+      const axisem3d::eigen::DMatXN& C34,
+      const axisem3d::eigen::DMatXN& C35,
+      const axisem3d::eigen::DMatXN& C36,
       // C4
-      const eigen::DMatXN& C44,
-      const eigen::DMatXN& C45,
-      const eigen::DMatXN& C46,
+      const axisem3d::eigen::DMatXN& C44,
+      const axisem3d::eigen::DMatXN& C45,
+      const axisem3d::eigen::DMatXN& C46,
       // C5
-      const eigen::DMatXN& C55,
-      const eigen::DMatXN& C56,
+      const axisem3d::eigen::DMatXN& C55,
+      const axisem3d::eigen::DMatXN& C56,
       // C6
-      const eigen::DMatXN& C66) :
+      const axisem3d::eigen::DMatXN& C66) :
       Elastic(false, attenuation), mC11(C11), mC12(C12), mC13(C13), mC14(C14), mC15(C15), mC16(C16),
       mC22(C22), mC23(C23), mC24(C24), mC25(C25), mC26(C26), mC33(C33), mC34(C34), mC35(C35),
       mC36(C36), mC44(C44), mC45(C45), mC46(C46), mC55(C55), mC56(C56), mC66(C66) {
@@ -130,8 +130,9 @@ class Anisotropic : public Elastic {
 
   // strain => stress in Fourier space
   void
-  strainToStress_FR(
-      const eigen::vec_ar6_CMatPP_RM& strain, eigen::vec_ar6_CMatPP_RM& stress, int nu_1) const {
+  strainToStress_FR(const axisem3d::eigen::vec_ar6_CMatPP_RM& strain,
+      axisem3d::eigen::vec_ar6_CMatPP_RM& stress,
+      int nu_1) const {
     // elasticity
     for (int alpha = 0; alpha < nu_1; alpha++) {
       strainToStress<CaseFA::_1D_FR>(strain,
@@ -166,7 +167,8 @@ class Anisotropic : public Elastic {
 
   // strain => stress in cardinal space
   void
-  strainToStress_CD(const eigen::RMatXN6& strain, eigen::RMatXN6& stress, int nr) const {
+  strainToStress_CD(
+      const axisem3d::eigen::RMatXN6& strain, axisem3d::eigen::RMatXN6& stress, int nr) const {
     // elasticity
     if (m1D) {
       strainToStress<CaseFA::_1D_CD>(strain,

--- a/src/core/element/material/elastic/anisotropy/Isotropic.hpp
+++ b/src/core/element/material/elastic/anisotropy/Isotropic.hpp
@@ -27,12 +27,12 @@ class Isotropic : public Elastic {
   public:
   // 1D constructor
   Isotropic(std::unique_ptr<Attenuation>& attenuation,
-      const eigen::DMatPP_RM& lambda,
-      const eigen::DMatPP_RM& mu) :
+      const axisem3d::eigen::DMatPP_RM& lambda,
+      const axisem3d::eigen::DMatPP_RM& mu) :
       Elastic(true, attenuation), mLambda(lambda), mMu(mu)
 #ifndef AXISEM3D_SAVE_MEMORY
       ,
-      mMu2(eigen::DMatPP_RM(mu * 2.))
+      mMu2(axisem3d::eigen::DMatPP_RM(mu * 2.))
 #endif
   {
     // nothing
@@ -40,12 +40,12 @@ class Isotropic : public Elastic {
 
   // 3D constructor
   Isotropic(std::unique_ptr<Attenuation>& attenuation,
-      const eigen::DMatXN& lambda,
-      const eigen::DMatXN& mu) :
+      const axisem3d::eigen::DMatXN& lambda,
+      const axisem3d::eigen::DMatXN& mu) :
       Elastic(false, attenuation), mLambda(lambda), mMu(mu)
 #ifndef AXISEM3D_SAVE_MEMORY
       ,
-      mMu2(eigen::DMatXN(mu * 2.))
+      mMu2(axisem3d::eigen::DMatXN(mu * 2.))
 #endif
   {
     // nothing
@@ -92,8 +92,9 @@ class Isotropic : public Elastic {
 
   // strain => stress in Fourier space
   void
-  strainToStress_FR(
-      const eigen::vec_ar6_CMatPP_RM& strain, eigen::vec_ar6_CMatPP_RM& stress, int nu_1) const {
+  strainToStress_FR(const axisem3d::eigen::vec_ar6_CMatPP_RM& strain,
+      axisem3d::eigen::vec_ar6_CMatPP_RM& stress,
+      int nu_1) const {
     // elasticity
 #ifdef AXISEM3D_SAVE_MEMORY
     computeMu2();
@@ -108,7 +109,8 @@ class Isotropic : public Elastic {
 
   // strain => stress in cardinal space
   void
-  strainToStress_CD(const eigen::RMatXN6& strain, eigen::RMatXN6& stress, int nr) const {
+  strainToStress_CD(
+      const axisem3d::eigen::RMatXN6& strain, axisem3d::eigen::RMatXN6& stress, int nr) const {
     // elasticity
 #ifdef AXISEM3D_SAVE_MEMORY
     computeMu2();

--- a/src/core/element/material/elastic/anisotropy/TransverselyIsotropic.hpp
+++ b/src/core/element/material/elastic/anisotropy/TransverselyIsotropic.hpp
@@ -27,15 +27,15 @@ class TransverselyIsotropic : public Elastic {
   public:
   // 1D constructor
   TransverselyIsotropic(std::unique_ptr<Attenuation>& attenuation,
-      const eigen::DMatPP_RM& A,
-      const eigen::DMatPP_RM& C,
-      const eigen::DMatPP_RM& F,
-      const eigen::DMatPP_RM& L,
-      const eigen::DMatPP_RM& N) :
+      const axisem3d::eigen::DMatPP_RM& A,
+      const axisem3d::eigen::DMatPP_RM& C,
+      const axisem3d::eigen::DMatPP_RM& F,
+      const axisem3d::eigen::DMatPP_RM& L,
+      const axisem3d::eigen::DMatPP_RM& N) :
       Elastic(true, attenuation), mA(A), mC(C), mF(F), mL(L), mN(N)
 #ifndef AXISEM3D_SAVE_MEMORY
       ,
-      mMinusN2(eigen::DMatPP_RM(N * (-2.)))
+      mMinusN2(axisem3d::eigen::DMatPP_RM(N * (-2.)))
 #endif
   {
     // nothing
@@ -43,15 +43,15 @@ class TransverselyIsotropic : public Elastic {
 
   // 3D constructor
   TransverselyIsotropic(std::unique_ptr<Attenuation>& attenuation,
-      const eigen::DMatXN& A,
-      const eigen::DMatXN& C,
-      const eigen::DMatXN& F,
-      const eigen::DMatXN& L,
-      const eigen::DMatXN& N) :
+      const axisem3d::eigen::DMatXN& A,
+      const axisem3d::eigen::DMatXN& C,
+      const axisem3d::eigen::DMatXN& F,
+      const axisem3d::eigen::DMatXN& L,
+      const axisem3d::eigen::DMatXN& N) :
       Elastic(false, attenuation), mA(A), mC(C), mF(F), mL(L), mN(N)
 #ifndef AXISEM3D_SAVE_MEMORY
       ,
-      mMinusN2(eigen::DMatXN(N * (-2.)))
+      mMinusN2(axisem3d::eigen::DMatXN(N * (-2.)))
 #endif
   {
     // nothing
@@ -98,8 +98,9 @@ class TransverselyIsotropic : public Elastic {
 
   // strain => stress in Fourier space
   void
-  strainToStress_FR(
-      const eigen::vec_ar6_CMatPP_RM& strain, eigen::vec_ar6_CMatPP_RM& stress, int nu_1) const {
+  strainToStress_FR(const axisem3d::eigen::vec_ar6_CMatPP_RM& strain,
+      axisem3d::eigen::vec_ar6_CMatPP_RM& stress,
+      int nu_1) const {
     // elasticity
 #ifdef AXISEM3D_SAVE_MEMORY
     computeMinusN2();
@@ -114,7 +115,8 @@ class TransverselyIsotropic : public Elastic {
 
   // strain => stress in cardinal space
   void
-  strainToStress_CD(const eigen::RMatXN6& strain, eigen::RMatXN6& stress, int nr) const {
+  strainToStress_CD(
+      const axisem3d::eigen::RMatXN6& strain, axisem3d::eigen::RMatXN6& stress, int nr) const {
     // elasticity
 #ifdef AXISEM3D_SAVE_MEMORY
     computeMinusN2();

--- a/src/core/element/material/elastic/attenuation/Attenuation.hpp
+++ b/src/core/element/material/elastic/attenuation/Attenuation.hpp
@@ -24,11 +24,11 @@
 #include "eigen_element.hpp"
 #include "FieldArithmetic.hpp"
 
-namespace eigen {
+namespace axisem3d::eigen {
   // alpha, beta, gamma
   typedef Eigen::Matrix<double, Eigen::Dynamic, 1> DColX;
   typedef Eigen::Matrix<numerical::Real, Eigen::Dynamic, 1> RColX;
-} // namespace eigen
+} // namespace axisem3d::eigen
 
 class Attenuation {
   public:
@@ -66,11 +66,13 @@ class Attenuation {
   //////////////////////// apply ////////////////////////
   // apply attenuation in Fourier space
   virtual void
-  apply(const eigen::vec_ar6_CMatPP_RM& strain, eigen::vec_ar6_CMatPP_RM& stress, int nu_1) = 0;
+  apply(const axisem3d::eigen::vec_ar6_CMatPP_RM& strain,
+      axisem3d::eigen::vec_ar6_CMatPP_RM& stress,
+      int nu_1) = 0;
 
   // apply attenuation in cardinal space
   virtual void
-  apply(const eigen::RMatXN6& strain, eigen::RMatXN6& stress, int nr) = 0;
+  apply(const axisem3d::eigen::RMatXN6& strain, axisem3d::eigen::RMatXN6& stress, int nr) = 0;
 
   //////////////////////// data ////////////////////////
   protected:
@@ -136,8 +138,9 @@ class Attenuation {
   public:
   // set alpha, beta, gamma
   static void
-  setAlphaBetaGamma(
-      const eigen::DColX& alpha, const eigen::DColX& betta, const eigen::DColX& gamma) {
+  setAlphaBetaGamma(const axisem3d::eigen::DColX& alpha,
+      const axisem3d::eigen::DColX& betta,
+      const axisem3d::eigen::DColX& gamma) {
     sAlpha = alpha.cast<numerical::Real>();
     sBetta = betta.cast<numerical::Real>();
     sGamma = gamma.cast<numerical::Real>();
@@ -145,9 +148,9 @@ class Attenuation {
 
   private:
   // coeffs
-  inline static eigen::RColX sAlpha;
-  inline static eigen::RColX sBetta;
-  inline static eigen::RColX sGamma;
+  inline static axisem3d::eigen::RColX sAlpha;
+  inline static axisem3d::eigen::RColX sBetta;
+  inline static axisem3d::eigen::RColX sGamma;
 };
 
 #endif /* Attenuation_hpp */

--- a/src/core/element/material/elastic/attenuation/AttenuationCG4.hpp
+++ b/src/core/element/material/elastic/attenuation/AttenuationCG4.hpp
@@ -14,7 +14,7 @@
 
 #include "Attenuation.hpp"
 
-namespace eigen {
+namespace axisem3d::eigen {
   // Fourier
   typedef Eigen::Matrix<double, 2, 2, Eigen::RowMajor> DMat22_RM;
   typedef Eigen::Matrix<numerical::Real, 2, 2, Eigen::RowMajor> RMat22_RM;
@@ -25,7 +25,7 @@ namespace eigen {
   typedef Eigen::Matrix<double, Eigen::Dynamic, 4> DMatX4;
   typedef Eigen::Matrix<numerical::Real, Eigen::Dynamic, 4> RMatX4;
   typedef Eigen::Matrix<numerical::Real, Eigen::Dynamic, 4 * 6> RMatX46;
-} // namespace eigen
+} // namespace axisem3d::eigen
 
 namespace fa4 {
   // property class
@@ -38,22 +38,22 @@ namespace fa4 {
 class AttenuationCG4 : public Attenuation {
   public:
   // 1D constructor
-  AttenuationCG4(const eigen::DMat22_RM& dLambda, const eigen::DMat22_RM& dMu) :
+  AttenuationCG4(const axisem3d::eigen::DMat22_RM& dLambda, const axisem3d::eigen::DMat22_RM& dMu) :
       Attenuation(true), mDLambda(dLambda), mDMu(dMu)
 #ifndef AXISEM3D_SAVE_MEMORY
       ,
-      mDMu2(eigen::DMat22_RM(dMu * 2.))
+      mDMu2(axisem3d::eigen::DMat22_RM(dMu * 2.))
 #endif
   {
     // nothing
   }
 
   // 3D constructor
-  AttenuationCG4(const eigen::DMatX4& dLambda, const eigen::DMatX4& dMu) :
+  AttenuationCG4(const axisem3d::eigen::DMatX4& dLambda, const axisem3d::eigen::DMatX4& dMu) :
       Attenuation(false), mDLambda(dLambda), mDMu(dMu)
 #ifndef AXISEM3D_SAVE_MEMORY
       ,
-      mDMu2(eigen::DMatX4(dMu * 2.))
+      mDMu2(axisem3d::eigen::DMatX4(dMu * 2.))
 #endif
   {
     // nothing
@@ -93,13 +93,13 @@ class AttenuationCG4 : public Attenuation {
     if (elemInFourier) {
       mDStress_FR.resize(nu_1);
       for (int alpha = 0; alpha < nu_1; alpha++) {
-        mDStress_FR[alpha].fill(eigen::CMat22_RM::Zero());
+        mDStress_FR[alpha].fill(axisem3d::eigen::CMat22_RM::Zero());
       }
       mDStress_CD.resize(0, 4 * 6);
     } else {
       mDStress_FR.clear();
       mDStress_FR.shrink_to_fit();
-      mDStress_CD = eigen::RMatX46::Zero(nr, 4 * 6);
+      mDStress_CD = axisem3d::eigen::RMatX46::Zero(nr, 4 * 6);
     }
     mMemVar_FR.assign(nsls(), mDStress_FR);
     mMemVar_CD.assign(nsls(), mDStress_CD);
@@ -138,7 +138,9 @@ class AttenuationCG4 : public Attenuation {
   //////////////////////// apply ////////////////////////
   // apply attenuation in Fourier space
   void
-  apply(const eigen::vec_ar6_CMatPP_RM& strain, eigen::vec_ar6_CMatPP_RM& stress, int nu_1) {
+  apply(const axisem3d::eigen::vec_ar6_CMatPP_RM& strain,
+      axisem3d::eigen::vec_ar6_CMatPP_RM& stress,
+      int nu_1) {
 #ifdef AXISEM3D_SAVE_MEMORY
     computeDMu2();
 #endif
@@ -150,7 +152,7 @@ class AttenuationCG4 : public Attenuation {
 
   // apply attenuation in cardinal space
   void
-  apply(const eigen::RMatXN6& strain, eigen::RMatXN6& stress, int nr) {
+  apply(const axisem3d::eigen::RMatXN6& strain, axisem3d::eigen::RMatXN6& stress, int nr) {
 #ifdef AXISEM3D_SAVE_MEMORY
     computeDMu2();
 #endif
@@ -184,16 +186,16 @@ class AttenuationCG4 : public Attenuation {
 #endif
 
   // memory variables in Fourier space
-  eigen::vec_ar6_CMat22_RM mDStress_FR;
-  std::vector<eigen::vec_ar6_CMat22_RM> mMemVar_FR;
+  axisem3d::eigen::vec_ar6_CMat22_RM mDStress_FR;
+  std::vector<axisem3d::eigen::vec_ar6_CMat22_RM> mMemVar_FR;
 
   // memory variables in cardinal space
-  eigen::RMatX46 mDStress_CD;
-  std::vector<eigen::RMatX46> mMemVar_CD;
+  axisem3d::eigen::RMatX46 mDStress_CD;
+  std::vector<axisem3d::eigen::RMatX46> mMemVar_CD;
 
   // workspace
-  inline static eigen::vec_ar6_CMat22_RM sStrain4_FR;
-  inline static eigen::RMatX46 sStrain4_CD;
+  inline static axisem3d::eigen::vec_ar6_CMat22_RM sStrain4_FR;
+  inline static axisem3d::eigen::RMatX46 sStrain4_CD;
 
   /////////////////////////////////////////////////////////////////////
   /////////////////// template-based implementation ///////////////////
@@ -204,7 +206,7 @@ class AttenuationCG4 : public Attenuation {
   static typename std::enable_if<CASE == CaseFA::_1D_FR, void>::type
   subtractMemFromStress(const std::vector<FCG6>& memVar, FMat6& stressN, int nx) {
     for (int isls = 0; isls < nsls(); isls++) {
-      const eigen::vec_ar6_CMat22_RM& memVar4 = memVar[isls];
+      const axisem3d::eigen::vec_ar6_CMat22_RM& memVar4 = memVar[isls];
       for (int idim = 0; idim < 6; idim++) {
         stressN[nx][idim](1, 1) -= memVar4[nx][idim](0, 0);
         stressN[nx][idim](1, 3) -= memVar4[nx][idim](0, 1);
@@ -235,7 +237,7 @@ class AttenuationCG4 : public Attenuation {
 
     // subtract
     for (int isls = 0; isls < nsls(); isls++) {
-      const eigen::RMatX46& memVar4 = memVar[isls];
+      const axisem3d::eigen::RMatX46& memVar4 = memVar[isls];
       stressN(seqRow, seqN0) -= memVar4(seqRow, seq40);
       stressN(seqRow, seqN1) -= memVar4(seqRow, seq41);
       stressN(seqRow, seqN2) -= memVar4(seqRow, seq42);
@@ -246,7 +248,9 @@ class AttenuationCG4 : public Attenuation {
   /////////////////// strain => strain4 ///////////////////
   // CASE == _1D_FR
   static void
-  formStrain4(const eigen::vec_ar6_CMatPP_RM& strainN, eigen::vec_ar6_CMat22_RM& strain4, int nx) {
+  formStrain4(const axisem3d::eigen::vec_ar6_CMatPP_RM& strainN,
+      axisem3d::eigen::vec_ar6_CMat22_RM& strain4,
+      int nx) {
     for (int idim = 0; idim < 6; idim++) {
       strain4[nx][idim](0, 0) = strainN[nx][idim](1, 1);
       strain4[nx][idim](0, 1) = strainN[nx][idim](1, 3);
@@ -256,7 +260,7 @@ class AttenuationCG4 : public Attenuation {
   }
   // CASE != _1D_FR
   static void
-  formStrain4(const eigen::RMatXN6& strainN, eigen::RMatX46& strain4, int nx) {
+  formStrain4(const axisem3d::eigen::RMatXN6& strainN, axisem3d::eigen::RMatX46& strain4, int nx) {
     using spectral::nPEM;
     using spectral::nPED;
 

--- a/src/core/element/material/elastic/attenuation/AttenuationFull.hpp
+++ b/src/core/element/material/elastic/attenuation/AttenuationFull.hpp
@@ -18,22 +18,23 @@
 class AttenuationFull : public Attenuation {
   public:
   // 1D constructor
-  AttenuationFull(const eigen::DMatPP_RM& dLambda, const eigen::DMatPP_RM& dMu) :
+  AttenuationFull(
+      const axisem3d::eigen::DMatPP_RM& dLambda, const axisem3d::eigen::DMatPP_RM& dMu) :
       Attenuation(true), mDLambda(dLambda), mDMu(dMu)
 #ifndef AXISEM3D_SAVE_MEMORY
       ,
-      mDMu2(eigen::DMatPP_RM(dMu * 2.))
+      mDMu2(axisem3d::eigen::DMatPP_RM(dMu * 2.))
 #endif
   {
     // nothing
   }
 
   // 3D constructor
-  AttenuationFull(const eigen::DMatXN& dLambda, const eigen::DMatXN& dMu) :
+  AttenuationFull(const axisem3d::eigen::DMatXN& dLambda, const axisem3d::eigen::DMatXN& dMu) :
       Attenuation(false), mDLambda(dLambda), mDMu(dMu)
 #ifndef AXISEM3D_SAVE_MEMORY
       ,
-      mDMu2(eigen::DMatXN(dMu * 2.))
+      mDMu2(axisem3d::eigen::DMatXN(dMu * 2.))
 #endif
   {
     // nothing
@@ -67,13 +68,13 @@ class AttenuationFull : public Attenuation {
       int nu_1 = nr / 2 + 1;
       mDStress_FR.resize(nu_1);
       for (int alpha = 0; alpha < nu_1; alpha++) {
-        mDStress_FR[alpha].fill(eigen::CMatPP_RM::Zero());
+        mDStress_FR[alpha].fill(axisem3d::eigen::CMatPP_RM::Zero());
       }
       mDStress_CD.resize(0, spectral::nPEM * 6);
     } else {
       mDStress_FR.clear();
       mDStress_FR.shrink_to_fit();
-      mDStress_CD = eigen::RMatXN6::Zero(nr, spectral::nPEM * 6);
+      mDStress_CD = axisem3d::eigen::RMatXN6::Zero(nr, spectral::nPEM * 6);
     }
     mMemVar_FR.assign(nsls(), mDStress_FR);
     mMemVar_CD.assign(nsls(), mDStress_CD);
@@ -103,7 +104,9 @@ class AttenuationFull : public Attenuation {
   //////////////////////// apply ////////////////////////
   // apply attenuation in Fourier space
   void
-  apply(const eigen::vec_ar6_CMatPP_RM& strain, eigen::vec_ar6_CMatPP_RM& stress, int nu_1) {
+  apply(const axisem3d::eigen::vec_ar6_CMatPP_RM& strain,
+      axisem3d::eigen::vec_ar6_CMatPP_RM& stress,
+      int nu_1) {
 #ifdef AXISEM3D_SAVE_MEMORY
     computeDMu2();
 #endif
@@ -114,7 +117,7 @@ class AttenuationFull : public Attenuation {
 
   // apply attenuation in cardinal space
   void
-  apply(const eigen::RMatXN6& strain, eigen::RMatXN6& stress, int nr) {
+  apply(const axisem3d::eigen::RMatXN6& strain, axisem3d::eigen::RMatXN6& stress, int nr) {
 #ifdef AXISEM3D_SAVE_MEMORY
     computeDMu2();
 #endif
@@ -146,12 +149,12 @@ class AttenuationFull : public Attenuation {
 #endif
 
   // memory variables in Fourier space
-  eigen::vec_ar6_CMatPP_RM mDStress_FR;
-  std::vector<eigen::vec_ar6_CMatPP_RM> mMemVar_FR;
+  axisem3d::eigen::vec_ar6_CMatPP_RM mDStress_FR;
+  std::vector<axisem3d::eigen::vec_ar6_CMatPP_RM> mMemVar_FR;
 
   // memory variables in cardinal space
-  eigen::RMatXN6 mDStress_CD;
-  std::vector<eigen::RMatXN6> mMemVar_CD;
+  axisem3d::eigen::RMatXN6 mDStress_CD;
+  std::vector<axisem3d::eigen::RMatXN6> mMemVar_CD;
 
   /////////////////////////////////////////////////////////////////////
   /////////////////// template-based implementation ///////////////////

--- a/src/core/output/element-wise/eigen_element_op.hpp
+++ b/src/core/output/element-wise/eigen_element_op.hpp
@@ -15,7 +15,7 @@
 #include "eigen_station.hpp"
 #include "eigen_generic.hpp"
 
-namespace eigen {
+namespace axisem3d::eigen {
   using Eigen::Dynamic;
   using numerical::Real;
   using spectral::nPEM;
@@ -35,6 +35,6 @@ namespace eigen {
   typedef Eigen::Matrix<Real, Dynamic, nPEM * 3, Eigen::RowMajor> RMatXN3_RM;
   typedef Eigen::Matrix<Real, Dynamic, nPEM * 6, Eigen::RowMajor> RMatXN6_RM;
   typedef Eigen::Matrix<Real, Dynamic, nPEM * 9, Eigen::RowMajor> RMatXN9_RM;
-} // namespace eigen
+} // namespace axisem3d::eigen
 
 #endif /* eigen_element_op_hpp */

--- a/src/core/output/element-wise/element/ElementOp.hpp
+++ b/src/core/output/element-wise/element/ElementOp.hpp
@@ -36,8 +36,8 @@ class ElementOp {
   recordToElem(CMatXND& cxnd,
       int nu_1,
       RMatXND_RM& rxnd,
-      const eigen::CMatXX& expIAlphaPhi,
-      eigen::RTensor4& field,
+      const axisem3d::eigen::CMatXX& expIAlphaPhi,
+      axisem3d::eigen::RTensor4& field,
       int bufferLine) const {
     // inplane downsampling
     int npnts = (int)mIPnts.size();
@@ -68,43 +68,46 @@ class ElementOp {
     }
 
     // write to buffer (Nyquist truncated here)
-    static const eigen::IArray3 shuffle = {0, 2, 1};
-    static const eigen::IArray3 zero = {0, 0, 0};
+    static const axisem3d::eigen::IArray3 shuffle = {0, 2, 1};
+    static const axisem3d::eigen::IArray3 zero = {0, 0, 0};
     int na = (int)field.dimension(0);
-    field.slice(eigen::IArray4({0, 0, 0, bufferLine}), eigen::IArray4({na, npnts, D, 1}))
-        .reshape(eigen::IArray3{na, npnts, D}) = // the longest C++ statement I have written
-        Eigen::TensorMap<eigen::RTensor3>(
-            rxnd.data(), eigen::IArray3({rxnd.rows(), rxnd.cols(), 1}))
-            .slice(zero, eigen::IArray3({na, npntsD, 1}))
-            .reshape(eigen::IArray3{na, D, npnts})
+    field
+        .slice(axisem3d::eigen::IArray4({0, 0, 0, bufferLine}),
+            axisem3d::eigen::IArray4({na, npnts, D, 1}))
+        .reshape(
+            axisem3d::eigen::IArray3{na, npnts, D}) = // the longest C++ statement I have written
+        Eigen::TensorMap<axisem3d::eigen::RTensor3>(
+            rxnd.data(), axisem3d::eigen::IArray3({rxnd.rows(), rxnd.cols(), 1}))
+            .slice(zero, axisem3d::eigen::IArray3({na, npntsD, 1}))
+            .reshape(axisem3d::eigen::IArray3{na, D, npnts})
             .shuffle(shuffle);
   }
 
   // dump: compute channel and feed IO buffer
   template <int D>
   static void
-  dumpToIO(const eigen::RTensor4& field,
+  dumpToIO(const axisem3d::eigen::RTensor4& field,
       int fieldIndex,
       int bufferLine,
       int channelIndex,
       int elemIndexNaGrid,
       int naGridIndex,
-      std::vector<eigen::RTensor5>& ioBuffers) {
+      std::vector<axisem3d::eigen::RTensor5>& ioBuffers) {
     // result reference
     int na = (int)field.dimension(0);
     int npnts = (int)field.dimension(1);
-    eigen::IArray5 loc5 = {elemIndexNaGrid, 0, 0, channelIndex, 0};
-    eigen::IArray5 len5 = {1, na, npnts, 1, bufferLine};
-    eigen::IArray3 copy = {na, npnts, bufferLine};
+    axisem3d::eigen::IArray5 loc5 = {elemIndexNaGrid, 0, 0, channelIndex, 0};
+    axisem3d::eigen::IArray5 len5 = {1, na, npnts, 1, bufferLine};
+    axisem3d::eigen::IArray3 copy = {na, npnts, bufferLine};
     auto res = ioBuffers[naGridIndex].slice(loc5, len5).reshape(copy);
 
     // indexing of input elemBuffer
-    eigen::IArray4 loc4 = {0, 0, 0, 0};
-    eigen::IArray4 len4 = {na, npnts, 1, bufferLine};
+    axisem3d::eigen::IArray4 loc4 = {0, 0, 0, 0};
+    axisem3d::eigen::IArray4 len4 = {na, npnts, 1, bufferLine};
 
     // channel index
     static const int chrank = 2;
-    static const eigen::IArray1 chDim = {2};
+    static const axisem3d::eigen::IArray1 chDim = {2};
 
     // channel
     if (fieldIndex >= 0) {
@@ -139,7 +142,7 @@ class ElementOp {
           res = (field.slice(loc4, len4).sum(chDim).square() * numerical::Real(1. / 3));
           // I2: permutation 0, 1, 2
           len4[chrank] = 1;
-          eigen::IArray4 lox4 = loc4;
+          axisem3d::eigen::IArray4 lox4 = loc4;
           for (int dim = 0; dim < 3; dim++) {
             loc4[chrank] = dim;
             lox4[chrank] = (dim == 2) ? 0 : (dim + 1);

--- a/src/core/output/element-wise/element/ElementOpFluid.cpp
+++ b/src/core/output/element-wise/element/ElementOpFluid.cpp
@@ -45,7 +45,7 @@ ElementOpFluid::setInGroup(int dumpIntv, const channel::fluid::ChannelOptions& c
 void
 ElementOpFluid::record(int bufferLine,
     const channel::fluid::ChannelOptions& chops,
-    const eigen::CMatXX& expIAlphaPhi) {
+    const axisem3d::eigen::CMatXX& expIAlphaPhi) {
   int nu_1 = mElement->getNu_1();
   bool needRTZ = (chops.mWCS == channel::WavefieldCS::RTZ);
 
@@ -74,7 +74,7 @@ ElementOpFluid::processReport(int bufferLine,
     const channel::fluid::ChannelOptions& chops,
     int elemIndexNaGrid,
     int naGridIndex,
-    std::vector<eigen::RTensor5>& ioBuffers) {
+    std::vector<axisem3d::eigen::RTensor5>& ioBuffers) {
   // loop over channels
   for (int ich = 0; ich < chops.mStdChannels.size(); ich++) {
     // find field and index of channel

--- a/src/core/output/element-wise/element/ElementOpFluid.hpp
+++ b/src/core/output/element-wise/element/ElementOpFluid.hpp
@@ -58,9 +58,9 @@ class ElementOpFluid : public ElementOp {
   }
 
   // get coords
-  eigen::DRowX
+  axisem3d::eigen::DRowX
   getCoords() const {
-    eigen::DRowX sz(mIPnts.size() * 2);
+    axisem3d::eigen::DRowX sz(mIPnts.size() * 2);
     for (int ip = 0; ip < mIPnts.size(); ip++) {
       sz.block(0, ip * 2, 1, 2) = mElement->getPoint(mIPnts[ip]).getCoords();
     }
@@ -73,17 +73,17 @@ class ElementOpFluid : public ElementOp {
   void
   record(int bufferLine,
       const channel::fluid::ChannelOptions& chops,
-      const eigen::CMatXX& expIAlphaPhi);
+      const axisem3d::eigen::CMatXX& expIAlphaPhi);
 
   private:
   // element
   std::shared_ptr<FluidElement> mElement = nullptr;
 
   // buffer
-  eigen::RTensor4 mBufferX;
-  eigen::RTensor4 mBufferU;
-  eigen::RTensor4 mBufferP;
-  eigen::RTensor4 mBufferD;
+  axisem3d::eigen::RTensor4 mBufferX;
+  axisem3d::eigen::RTensor4 mBufferU;
+  axisem3d::eigen::RTensor4 mBufferP;
+  axisem3d::eigen::RTensor4 mBufferD;
 
   /////////////////////////// process ///////////////////////////
   public:
@@ -93,7 +93,7 @@ class ElementOpFluid : public ElementOp {
       const channel::fluid::ChannelOptions& chops,
       int elemIndexNaGrid,
       int naGridIndex,
-      std::vector<eigen::RTensor5>& ioBuffers);
+      std::vector<axisem3d::eigen::RTensor5>& ioBuffers);
 
   ////////////////////////////////////////
   //////////////// static ////////////////
@@ -142,16 +142,20 @@ class ElementOpFluid : public ElementOp {
 
   // workspace for record
   // get response from elememt
-  inline static eigen::CMatXN sCXXN1 = eigen::CMatXN(0, spectral::nPEM * 1);
-  inline static eigen::CMatXN3 sCUXN3 = eigen::CMatXN3(0, spectral::nPEM * 3);
-  inline static eigen::CMatXN sCPXN1 = eigen::CMatXN(0, spectral::nPEM * 1);
-  inline static eigen::CMatXN sCDXN1 = eigen::CMatXN(0, spectral::nPEM * 1);
+  inline static axisem3d::eigen::CMatXN sCXXN1 = axisem3d::eigen::CMatXN(0, spectral::nPEM * 1);
+  inline static axisem3d::eigen::CMatXN3 sCUXN3 = axisem3d::eigen::CMatXN3(0, spectral::nPEM * 3);
+  inline static axisem3d::eigen::CMatXN sCPXN1 = axisem3d::eigen::CMatXN(0, spectral::nPEM * 1);
+  inline static axisem3d::eigen::CMatXN sCDXN1 = axisem3d::eigen::CMatXN(0, spectral::nPEM * 1);
 
   // making real
-  inline static eigen::RMatXN_RM sRXXN1 = eigen::RMatXN_RM(0, spectral::nPEM * 1);
-  inline static eigen::RMatXN3_RM sRUXN3 = eigen::RMatXN3_RM(0, spectral::nPEM * 3);
-  inline static eigen::RMatXN_RM sRPXN1 = eigen::RMatXN_RM(0, spectral::nPEM * 1);
-  inline static eigen::RMatXN_RM sRDXN1 = eigen::RMatXN_RM(0, spectral::nPEM * 1);
+  inline static axisem3d::eigen::RMatXN_RM sRXXN1 =
+      axisem3d::eigen::RMatXN_RM(0, spectral::nPEM * 1);
+  inline static axisem3d::eigen::RMatXN3_RM sRUXN3 =
+      axisem3d::eigen::RMatXN3_RM(0, spectral::nPEM * 3);
+  inline static axisem3d::eigen::RMatXN_RM sRPXN1 =
+      axisem3d::eigen::RMatXN_RM(0, spectral::nPEM * 1);
+  inline static axisem3d::eigen::RMatXN_RM sRDXN1 =
+      axisem3d::eigen::RMatXN_RM(0, spectral::nPEM * 1);
 };
 
 #endif /* ElementOpFluid_hpp */

--- a/src/core/output/element-wise/element/ElementOpGroup.hpp
+++ b/src/core/output/element-wise/element/ElementOpGroup.hpp
@@ -82,9 +82,9 @@ template <class ElementOpT> class ElementOpGroup {
         maxNu_1 = std::max(maxNu_1, eop->getNu_1());
       }
       // allocate and compute
-      mExpIAlphaPhi = eigen::CMatXX::Zero(maxNu_1, nphis);
+      mExpIAlphaPhi = axisem3d::eigen::CMatXX::Zero(maxNu_1, nphis);
       for (int iphi = 0; iphi < nphis; iphi++) {
-        eigen::CColX temp(maxNu_1);
+        axisem3d::eigen::CColX temp(maxNu_1);
         eigen_tools::computeTwoExpIAlphaPhi(maxNu_1, mPhis[iphi], temp);
         mExpIAlphaPhi.col(iphi) = temp;
       }
@@ -133,8 +133,8 @@ template <class ElementOpT> class ElementOpGroup {
 
     //////////// element-na info and coords ////////////
     std::vector<int> numElemNaGrid = std::vector<int>(mNaGrid.size(), 0);
-    mElemNaInfo = eigen::IMatX4_RM(nelem, 4);
-    eigen::DMatXX_RM elemCoords(nelem, mNPnts * 2);
+    mElemNaInfo = axisem3d::eigen::IMatX4_RM(nelem, 4);
+    axisem3d::eigen::DMatXX_RM elemCoords(nelem, mNPnts * 2);
     for (int ielem = 0; ielem < nelem; ielem++) {
       mElemNaInfo(ielem, 0) = allTag[ielem];
       mElemNaInfo(ielem, 1) = allNa[ielem];
@@ -155,7 +155,8 @@ template <class ElementOpT> class ElementOpGroup {
       mBufferTime.resize(mDumpIntv);
     }
     for (int inag = 0; inag < mNaGrid.size(); inag++) {
-      eigen::RTensor5 bufferField(numElemNaGrid[inag], mNaGrid[inag], mNPnts, nch, mDumpIntv);
+      axisem3d::eigen::RTensor5 bufferField(
+          numElemNaGrid[inag], mNaGrid[inag], mNPnts, nch, mDumpIntv);
       mBufferFields.push_back(bufferField);
     }
     mBufferLine = 0;
@@ -258,16 +259,16 @@ template <class ElementOpT> class ElementOpGroup {
   std::vector<std::unique_ptr<ElementOpT>> mElementOps;
 
   // Fourier
-  eigen::CMatXX mExpIAlphaPhi = eigen::CMatXX(0, 0);
+  axisem3d::eigen::CMatXX mExpIAlphaPhi = axisem3d::eigen::CMatXX(0, 0);
 
   // na
   std::vector<int> mNaGrid;
   std::map<int, int> mNaGridIndexDict;
-  eigen::IMatX4_RM mElemNaInfo;
+  axisem3d::eigen::IMatX4_RM mElemNaInfo;
 
   // buffer
-  eigen::DColX mBufferTime = eigen::DColX(0);
-  std::vector<eigen::RTensor5> mBufferFields;
+  axisem3d::eigen::DColX mBufferTime = axisem3d::eigen::DColX(0);
+  std::vector<axisem3d::eigen::RTensor5> mBufferFields;
   int mBufferLine = 0;
 };
 

--- a/src/core/output/element-wise/element/ElementOpSolid.cpp
+++ b/src/core/output/element-wise/element/ElementOpSolid.cpp
@@ -48,7 +48,7 @@ ElementOpSolid::setInGroup(int dumpIntv, const channel::solid::ChannelOptions& c
 void
 ElementOpSolid::record(int bufferLine,
     const channel::solid::ChannelOptions& chops,
-    const eigen::CMatXX& expIAlphaPhi) {
+    const axisem3d::eigen::CMatXX& expIAlphaPhi) {
   int nu_1 = mElement->getNu_1();
   bool needRTZ = (chops.mWCS == channel::WavefieldCS::RTZ);
 
@@ -81,7 +81,7 @@ ElementOpSolid::processReport(int bufferLine,
     const channel::solid::ChannelOptions& chops,
     int elemIndexNaGrid,
     int naGridIndex,
-    std::vector<eigen::RTensor5>& ioBuffers) {
+    std::vector<axisem3d::eigen::RTensor5>& ioBuffers) {
   // loop over channels
   for (int ich = 0; ich < chops.mStdChannels.size(); ich++) {
     // find field and index of channel

--- a/src/core/output/element-wise/element/ElementOpSolid.hpp
+++ b/src/core/output/element-wise/element/ElementOpSolid.hpp
@@ -58,9 +58,9 @@ class ElementOpSolid : public ElementOp {
   }
 
   // get coords
-  eigen::DRowX
+  axisem3d::eigen::DRowX
   getCoords() const {
-    eigen::DRowX sz(mIPnts.size() * 2);
+    axisem3d::eigen::DRowX sz(mIPnts.size() * 2);
     for (int ip = 0; ip < mIPnts.size(); ip++) {
       sz.block(0, ip * 2, 1, 2) = mElement->getPoint(mIPnts[ip]).getCoords();
     }
@@ -73,18 +73,18 @@ class ElementOpSolid : public ElementOp {
   void
   record(int bufferLine,
       const channel::solid::ChannelOptions& chops,
-      const eigen::CMatXX& expIAlphaPhi);
+      const axisem3d::eigen::CMatXX& expIAlphaPhi);
 
   private:
   // element
   std::shared_ptr<SolidElement> mElement = nullptr;
 
   // buffer
-  eigen::RTensor4 mBufferU;
-  eigen::RTensor4 mBufferG;
-  eigen::RTensor4 mBufferE;
-  eigen::RTensor4 mBufferR;
-  eigen::RTensor4 mBufferS;
+  axisem3d::eigen::RTensor4 mBufferU;
+  axisem3d::eigen::RTensor4 mBufferG;
+  axisem3d::eigen::RTensor4 mBufferE;
+  axisem3d::eigen::RTensor4 mBufferR;
+  axisem3d::eigen::RTensor4 mBufferS;
 
   /////////////////////////// process ///////////////////////////
   public:
@@ -94,7 +94,7 @@ class ElementOpSolid : public ElementOp {
       const channel::solid::ChannelOptions& chops,
       int elemIndexNaGrid,
       int naGridIndex,
-      std::vector<eigen::RTensor5>& ioBuffers);
+      std::vector<axisem3d::eigen::RTensor5>& ioBuffers);
 
   ////////////////////////////////////////
   //////////////// static ////////////////
@@ -151,18 +151,23 @@ class ElementOpSolid : public ElementOp {
 
   // workspace for record
   // get response from elememt
-  inline static eigen::CMatXN3 sCUXN3 = eigen::CMatXN3(0, spectral::nPEM * 3);
-  inline static eigen::CMatXN9 sCGXN9 = eigen::CMatXN9(0, spectral::nPEM * 9);
-  inline static eigen::CMatXN6 sCEXN6 = eigen::CMatXN6(0, spectral::nPEM * 6);
-  inline static eigen::CMatXN3 sCRXN3 = eigen::CMatXN3(0, spectral::nPEM * 3);
-  inline static eigen::CMatXN6 sCSXN6 = eigen::CMatXN6(0, spectral::nPEM * 6);
+  inline static axisem3d::eigen::CMatXN3 sCUXN3 = axisem3d::eigen::CMatXN3(0, spectral::nPEM * 3);
+  inline static axisem3d::eigen::CMatXN9 sCGXN9 = axisem3d::eigen::CMatXN9(0, spectral::nPEM * 9);
+  inline static axisem3d::eigen::CMatXN6 sCEXN6 = axisem3d::eigen::CMatXN6(0, spectral::nPEM * 6);
+  inline static axisem3d::eigen::CMatXN3 sCRXN3 = axisem3d::eigen::CMatXN3(0, spectral::nPEM * 3);
+  inline static axisem3d::eigen::CMatXN6 sCSXN6 = axisem3d::eigen::CMatXN6(0, spectral::nPEM * 6);
 
   // making real
-  inline static eigen::RMatXN3_RM sRUXN3 = eigen::RMatXN3_RM(0, spectral::nPEM * 3);
-  inline static eigen::RMatXN9_RM sRGXN9 = eigen::RMatXN9_RM(0, spectral::nPEM * 9);
-  inline static eigen::RMatXN6_RM sREXN6 = eigen::RMatXN6_RM(0, spectral::nPEM * 6);
-  inline static eigen::RMatXN3_RM sRRXN3 = eigen::RMatXN3_RM(0, spectral::nPEM * 3);
-  inline static eigen::RMatXN6_RM sRSXN6 = eigen::RMatXN6_RM(0, spectral::nPEM * 6);
+  inline static axisem3d::eigen::RMatXN3_RM sRUXN3 =
+      axisem3d::eigen::RMatXN3_RM(0, spectral::nPEM * 3);
+  inline static axisem3d::eigen::RMatXN9_RM sRGXN9 =
+      axisem3d::eigen::RMatXN9_RM(0, spectral::nPEM * 9);
+  inline static axisem3d::eigen::RMatXN6_RM sREXN6 =
+      axisem3d::eigen::RMatXN6_RM(0, spectral::nPEM * 6);
+  inline static axisem3d::eigen::RMatXN3_RM sRRXN3 =
+      axisem3d::eigen::RMatXN3_RM(0, spectral::nPEM * 3);
+  inline static axisem3d::eigen::RMatXN6_RM sRSXN6 =
+      axisem3d::eigen::RMatXN6_RM(0, spectral::nPEM * 6);
 };
 
 #endif /* ElementOpSolid_hpp */

--- a/src/core/output/element-wise/io/ElementIO.cpp
+++ b/src/core/output/element-wise/io/ElementIO.cpp
@@ -20,8 +20,8 @@ ElementIO::initialize(const std::string& groupName,
     const std::vector<std::string>& channels,
     int npnts,
     const std::vector<int>& naGrid,
-    const eigen::IMatX4_RM& elemNaInfo,
-    const eigen::DMatXX_RM& elemCoords) {
+    const axisem3d::eigen::IMatX4_RM& elemNaInfo,
+    const axisem3d::eigen::DMatXX_RM& elemCoords) {
   // mpi globals
   int nelem = (int)elemNaInfo.rows();
   std::vector<int> nelemg;

--- a/src/core/output/element-wise/io/ElementIO.hpp
+++ b/src/core/output/element-wise/io/ElementIO.hpp
@@ -26,8 +26,8 @@ class ElementIO {
       const std::vector<std::string>& channels,
       int npnts,
       const std::vector<int>& naGrid,
-      const eigen::IMatX4_RM& elemNaInfo,
-      const eigen::DMatXX_RM& elemCoords);
+      const axisem3d::eigen::IMatX4_RM& elemNaInfo,
+      const axisem3d::eigen::DMatXX_RM& elemCoords);
 
   // finalize
   virtual void
@@ -35,8 +35,8 @@ class ElementIO {
 
   // dump to file
   virtual void
-  dumpToFile(const eigen::DColX& bufferTime,
-      const std::vector<eigen::RTensor5>& bufferFields,
+  dumpToFile(const axisem3d::eigen::DColX& bufferTime,
+      const std::vector<axisem3d::eigen::RTensor5>& bufferFields,
       int bufferLine) = 0;
 
   // set flush

--- a/src/core/output/element-wise/io/ElementIO_NetCDF.cpp
+++ b/src/core/output/element-wise/io/ElementIO_NetCDF.cpp
@@ -21,8 +21,8 @@ ElementIO_NetCDF::initialize(const std::string& groupName,
     const std::vector<std::string>& channels,
     int npnts,
     const std::vector<int>& naGrid,
-    const eigen::IMatX4_RM& elemNaInfo,
-    const eigen::DMatXX_RM& elemCoords) {
+    const axisem3d::eigen::IMatX4_RM& elemNaInfo,
+    const axisem3d::eigen::DMatXX_RM& elemCoords) {
   // finalize
   finalize();
 
@@ -32,7 +32,7 @@ ElementIO_NetCDF::initialize(const std::string& groupName,
   ///////////////////////////////////////////////////////////////////////
   // the fifth column: element index in data after concat
   // gather elements
-  std::vector<eigen::IMatX4_RM> elemNaInfoRanks;
+  std::vector<axisem3d::eigen::IMatX4_RM> elemNaInfoRanks;
   mpi::gatherEigen(elemNaInfo, elemNaInfoRanks, MPI_ALL);
 
   // form dict of naGrid for fast search
@@ -62,7 +62,7 @@ ElementIO_NetCDF::initialize(const std::string& groupName,
 
   // the fifth column
   int nelem = (int)elemNaInfo.rows();
-  eigen::IMatX5_RM elemNaInfo5(nelem, 5);
+  axisem3d::eigen::IMatX5_RM elemNaInfo5(nelem, 5);
   elemNaInfo5.leftCols(4) = elemNaInfo;
   for (int ielem = 0; ielem < nelem; ielem++) {
     int nag = elemNaInfo5(ielem, 2);
@@ -183,8 +183,8 @@ ElementIO_NetCDF::finalize() {
 
 // dump to file
 void
-ElementIO_NetCDF::dumpToFile(const eigen::DColX& bufferTime,
-    const std::vector<eigen::RTensor5>& bufferFields,
+ElementIO_NetCDF::dumpToFile(const axisem3d::eigen::DColX& bufferTime,
+    const std::vector<axisem3d::eigen::RTensor5>& bufferFields,
     int bufferLine) {
   // no element
   if (!mNcFile) {
@@ -217,10 +217,10 @@ ElementIO_NetCDF::dumpToFile(const eigen::DColX& bufferTime,
     } else {
       // must truncate by copy because time is the fastest varying
       // dimension; occuring only at the end of the simulation
-      eigen::IArray5 loc = {0, 0, 0, 0, 0};
-      eigen::IArray5 len = {nelem, nag, npnts, nch, bufferLine};
+      axisem3d::eigen::IArray5 loc = {0, 0, 0, 0, 0};
+      axisem3d::eigen::IArray5 len = {nelem, nag, npnts, nch, bufferLine};
       Eigen::internal::set_is_malloc_allowed(true);
-      eigen::RTensor5 timeTruncated = bufferFields[inag].slice(loc, len);
+      axisem3d::eigen::RTensor5 timeTruncated = bufferFields[inag].slice(loc, len);
       Eigen::internal::set_is_malloc_allowed(false);
       mNcFile->writeVariable(mVarID_Data[inag],
           "data_wave__NaG=" + strNag,

--- a/src/core/output/element-wise/io/ElementIO_NetCDF.hpp
+++ b/src/core/output/element-wise/io/ElementIO_NetCDF.hpp
@@ -24,8 +24,8 @@ class ElementIO_NetCDF : public ElementIO {
       const std::vector<std::string>& channels,
       int npnts,
       const std::vector<int>& naGrid,
-      const eigen::IMatX4_RM& elemNaInfo,
-      const eigen::DMatXX_RM& elemCoords);
+      const axisem3d::eigen::IMatX4_RM& elemNaInfo,
+      const axisem3d::eigen::DMatXX_RM& elemCoords);
 
   // finalize
   void
@@ -33,8 +33,8 @@ class ElementIO_NetCDF : public ElementIO {
 
   // dump to file
   void
-  dumpToFile(const eigen::DColX& bufferTime,
-      const std::vector<eigen::RTensor5>& bufferFields,
+  dumpToFile(const axisem3d::eigen::DColX& bufferTime,
+      const std::vector<axisem3d::eigen::RTensor5>& bufferFields,
       int bufferLine);
 
   private:

--- a/src/core/output/element-wise/io/ElementIO_ParNetCDF.cpp
+++ b/src/core/output/element-wise/io/ElementIO_ParNetCDF.cpp
@@ -21,8 +21,8 @@ ElementIO_ParNetCDF::initialize(const std::string& groupName,
     const std::vector<std::string>& channels,
     int npnts,
     const std::vector<int>& naGrid,
-    const eigen::IMatX4_RM& elemNaInfoL,
-    const eigen::DMatXX_RM& elemCoordsL) {
+    const axisem3d::eigen::IMatX4_RM& elemNaInfoL,
+    const axisem3d::eigen::DMatXX_RM& elemCoordsL) {
   // finalize
   finalize();
 
@@ -40,8 +40,8 @@ ElementIO_ParNetCDF::initialize(const std::string& groupName,
   const std::string& fname = gdir + "/axisem3d_synthetics.nc";
 
   // gather elements
-  std::vector<eigen::IMatX4_RM> elemNaInfoRanks;
-  std::vector<eigen::DMatXX_RM> elemCoordsRanks;
+  std::vector<axisem3d::eigen::IMatX4_RM> elemNaInfoRanks;
+  std::vector<axisem3d::eigen::DMatXX_RM> elemCoordsRanks;
   mpi::gatherEigen(elemNaInfoL, elemNaInfoRanks, mRankWithMaxNumElements);
   mpi::gatherEigen(elemCoordsL, elemCoordsRanks, mRankWithMaxNumElements);
 
@@ -55,8 +55,8 @@ ElementIO_ParNetCDF::initialize(const std::string& groupName,
   if (mpi::rank() == mRankWithMaxNumElements) {
     // flatten
     int ncrd = npnts * 2;
-    eigen::IMatX5_RM elemNaInfoAll(mNumElementsGlobal, 5);
-    eigen::DMatXX_RM elemCoordsAll(mNumElementsGlobal, ncrd);
+    axisem3d::eigen::IMatX5_RM elemNaInfoAll(mNumElementsGlobal, 5);
+    axisem3d::eigen::DMatXX_RM elemCoordsAll(mNumElementsGlobal, ncrd);
     int row = 0;
     for (int irank = 0; irank < mpi::nproc(); irank++) {
       int nelocal = (int)elemNaInfoRanks[irank].rows();
@@ -224,8 +224,8 @@ ElementIO_ParNetCDF::finalize() {
 
 // dump to file
 void
-ElementIO_ParNetCDF::dumpToFile(const eigen::DColX& bufferTime,
-    const std::vector<eigen::RTensor5>& bufferFields,
+ElementIO_ParNetCDF::dumpToFile(const axisem3d::eigen::DColX& bufferTime,
+    const std::vector<axisem3d::eigen::RTensor5>& bufferFields,
     int bufferLine) {
   // write time
   if (mpi::rank() == mRankWithMaxNumElements) {
@@ -255,10 +255,10 @@ ElementIO_ParNetCDF::dumpToFile(const eigen::DColX& bufferTime,
     } else {
       // must truncate by copy because time is the fastest varying
       // dimension; occuring only at the end of the simulation
-      eigen::IArray5 loc = {0, 0, 0, 0, 0};
-      eigen::IArray5 len = {nelem, nag, npnts, nch, bufferLine};
+      axisem3d::eigen::IArray5 loc = {0, 0, 0, 0, 0};
+      axisem3d::eigen::IArray5 len = {nelem, nag, npnts, nch, bufferLine};
       Eigen::internal::set_is_malloc_allowed(true);
-      eigen::RTensor5 timeTruncated = bufferFields[inag].slice(loc, len);
+      axisem3d::eigen::RTensor5 timeTruncated = bufferFields[inag].slice(loc, len);
       Eigen::internal::set_is_malloc_allowed(false);
       mNcFile->writeVariable(mVarID_Data[inag],
           "data_wave__NaG=" + strNag,

--- a/src/core/output/element-wise/io/ElementIO_ParNetCDF.hpp
+++ b/src/core/output/element-wise/io/ElementIO_ParNetCDF.hpp
@@ -24,8 +24,8 @@ class ElementIO_ParNetCDF : public ElementIO {
       const std::vector<std::string>& channels,
       int npnts,
       const std::vector<int>& naGrid,
-      const eigen::IMatX4_RM& elemNaInfo,
-      const eigen::DMatXX_RM& elemCoords);
+      const axisem3d::eigen::IMatX4_RM& elemNaInfo,
+      const axisem3d::eigen::DMatXX_RM& elemCoords);
 
   // finalize
   void
@@ -33,8 +33,8 @@ class ElementIO_ParNetCDF : public ElementIO {
 
   // dump to file
   void
-  dumpToFile(const eigen::DColX& bufferTime,
-      const std::vector<eigen::RTensor5>& bufferFields,
+  dumpToFile(const axisem3d::eigen::DColX& bufferTime,
+      const std::vector<axisem3d::eigen::RTensor5>& bufferFields,
       int bufferLine);
 
   private:

--- a/src/core/output/station-wise/eigen_station.hpp
+++ b/src/core/output/station-wise/eigen_station.hpp
@@ -15,7 +15,7 @@
 #include "eigen_tensor.hpp"
 #include "eigen_element.hpp"
 
-namespace eigen {
+namespace axisem3d::eigen {
   // tensor
   typedef Eigen::Tensor<numerical::Real, 3, Eigen::RowMajor> RTensor3;
   typedef Eigen::Tensor<numerical::Real, 1, Eigen::RowMajor> RTensor1;
@@ -48,6 +48,6 @@ namespace eigen {
   typedef Eigen::Matrix<Real, Eigen::Dynamic, 3, Eigen::RowMajor> RMatX3_RM;
   typedef Eigen::Matrix<Real, Eigen::Dynamic, 6, Eigen::RowMajor> RMatX6_RM;
   typedef Eigen::Matrix<Real, Eigen::Dynamic, 9, Eigen::RowMajor> RMatX9_RM;
-} // namespace eigen
+} // namespace axisem3d::eigen
 
 #endif /* eigen_station_hpp */

--- a/src/core/output/station-wise/io/StationIO.hpp
+++ b/src/core/output/station-wise/io/StationIO.hpp
@@ -32,8 +32,9 @@ class StationIO {
 
   // dump to file
   virtual void
-  dumpToFile(
-      const eigen::DColX& bufferTime, const eigen::RTensor3& bufferFields, int bufferLine) = 0;
+  dumpToFile(const axisem3d::eigen::DColX& bufferTime,
+      const axisem3d::eigen::RTensor3& bufferFields,
+      int bufferLine) = 0;
 
   // set flush
   void

--- a/src/core/output/station-wise/io/StationIO_Ascii.cpp
+++ b/src/core/output/station-wise/io/StationIO_Ascii.cpp
@@ -103,8 +103,9 @@ StationIO_Ascii::finalize() {
 
 // dump to file
 void
-StationIO_Ascii::dumpToFile(
-    const eigen::DColX& bufferTime, const eigen::RTensor3& bufferFields, int bufferLine) {
+StationIO_Ascii::dumpToFile(const axisem3d::eigen::DColX& bufferTime,
+    const axisem3d::eigen::RTensor3& bufferFields,
+    int bufferLine) {
   // no station
   int nst = (int)bufferFields.dimensions()[0];
   if (nst == 0) {
@@ -125,12 +126,12 @@ StationIO_Ascii::dumpToFile(
 
   // wavefields
   int nch = (int)bufferFields.dimensions()[1];
-  static const eigen::IArray2 shuffle = {1, 0};
+  static const axisem3d::eigen::IArray2 shuffle = {1, 0};
   Eigen::internal::set_is_malloc_allowed(true);
   if (mStationCentric) {
-    eigen::IArray3 loc = {0, 0, 0};
-    eigen::IArray3 len = {1, nch, bufferLine};
-    eigen::IArray2 shape = {nch, bufferLine};
+    axisem3d::eigen::IArray3 loc = {0, 0, 0};
+    axisem3d::eigen::IArray3 len = {1, nch, bufferLine};
+    axisem3d::eigen::IArray2 shape = {nch, bufferLine};
     for (int ist = 0; ist < nst; ist++) {
       loc[0] = ist;
       (*mFileStreams[ist + tfile])
@@ -140,9 +141,9 @@ StationIO_Ascii::dumpToFile(
       }
     }
   } else {
-    eigen::IArray3 loc = {0, 0, 0};
-    eigen::IArray3 len = {nst, 1, bufferLine};
-    eigen::IArray2 shape = {nst, bufferLine};
+    axisem3d::eigen::IArray3 loc = {0, 0, 0};
+    axisem3d::eigen::IArray3 len = {nst, 1, bufferLine};
+    axisem3d::eigen::IArray2 shape = {nst, bufferLine};
     for (int ich = 0; ich < nch; ich++) {
       loc[1] = ich;
       (*mFileStreams[ich + tfile])

--- a/src/core/output/station-wise/io/StationIO_Ascii.hpp
+++ b/src/core/output/station-wise/io/StationIO_Ascii.hpp
@@ -36,7 +36,9 @@ class StationIO_Ascii : public StationIO {
 
   // dump to file
   void
-  dumpToFile(const eigen::DColX& bufferTime, const eigen::RTensor3& bufferFields, int bufferLine);
+  dumpToFile(const axisem3d::eigen::DColX& bufferTime,
+      const axisem3d::eigen::RTensor3& bufferFields,
+      int bufferLine);
 
   private:
   // create file stream

--- a/src/core/output/station-wise/io/StationIO_NetCDF.cpp
+++ b/src/core/output/station-wise/io/StationIO_NetCDF.cpp
@@ -98,8 +98,9 @@ StationIO_NetCDF::finalize() {
 
 // dump to file
 void
-StationIO_NetCDF::dumpToFile(
-    const eigen::DColX& bufferTime, const eigen::RTensor3& bufferFields, int bufferLine) {
+StationIO_NetCDF::dumpToFile(const axisem3d::eigen::DColX& bufferTime,
+    const axisem3d::eigen::RTensor3& bufferFields,
+    int bufferLine) {
   // no station
   if (!mNcFile) {
     return;
@@ -120,10 +121,10 @@ StationIO_NetCDF::dumpToFile(
   } else {
     // must truncate by copy because time is the fastest varying
     // dimension; occuring only at the end of the simulation
-    eigen::IArray3 loc = {0, 0, 0};
-    eigen::IArray3 len = {nst, nch, bufferLine};
+    axisem3d::eigen::IArray3 loc = {0, 0, 0};
+    axisem3d::eigen::IArray3 len = {nst, nch, bufferLine};
     Eigen::internal::set_is_malloc_allowed(true);
-    eigen::RTensor3 timeTruncated = bufferFields.slice(loc, len);
+    axisem3d::eigen::RTensor3 timeTruncated = bufferFields.slice(loc, len);
     Eigen::internal::set_is_malloc_allowed(false);
     mNcFile->writeVariable(
         mVarID_Data, "data_wave", timeTruncated, {0, 0, mFileLineTime}, {nst, nch, bufferLine});

--- a/src/core/output/station-wise/io/StationIO_NetCDF.hpp
+++ b/src/core/output/station-wise/io/StationIO_NetCDF.hpp
@@ -30,7 +30,9 @@ class StationIO_NetCDF : public StationIO {
 
   // dump to file
   void
-  dumpToFile(const eigen::DColX& bufferTime, const eigen::RTensor3& bufferFields, int bufferLine);
+  dumpToFile(const axisem3d::eigen::DColX& bufferTime,
+      const axisem3d::eigen::RTensor3& bufferFields,
+      int bufferLine);
 
   private:
   //////////////////// const ////////////////////

--- a/src/core/output/station-wise/io/StationIO_ParNetCDF.cpp
+++ b/src/core/output/station-wise/io/StationIO_ParNetCDF.cpp
@@ -125,8 +125,9 @@ StationIO_ParNetCDF::finalize() {
 
 // dump to file
 void
-StationIO_ParNetCDF::dumpToFile(
-    const eigen::DColX& bufferTime, const eigen::RTensor3& bufferFields, int bufferLine) {
+StationIO_ParNetCDF::dumpToFile(const axisem3d::eigen::DColX& bufferTime,
+    const axisem3d::eigen::RTensor3& bufferFields,
+    int bufferLine) {
   // write time
   if (mpi::rank() == mRankWithMaxNumStations) {
     mNcFile->writeVariable(mVarID_Time, "data_time", bufferTime, {mFileLineTime}, {bufferLine});
@@ -148,10 +149,10 @@ StationIO_ParNetCDF::dumpToFile(
     } else {
       // must truncate by copy because time is the fastest varying
       // dimension; occuring only at the end of the simulation
-      eigen::IArray3 loc = {0, 0, 0};
-      eigen::IArray3 len = {nst, nch, bufferLine};
+      axisem3d::eigen::IArray3 loc = {0, 0, 0};
+      axisem3d::eigen::IArray3 len = {nst, nch, bufferLine};
       Eigen::internal::set_is_malloc_allowed(true);
-      eigen::RTensor3 timeTruncated = bufferFields.slice(loc, len);
+      axisem3d::eigen::RTensor3 timeTruncated = bufferFields.slice(loc, len);
       Eigen::internal::set_is_malloc_allowed(false);
       mNcFile->writeVariable(mVarID_Data,
           "data_wave",

--- a/src/core/output/station-wise/io/StationIO_ParNetCDF.hpp
+++ b/src/core/output/station-wise/io/StationIO_ParNetCDF.hpp
@@ -30,7 +30,9 @@ class StationIO_ParNetCDF : public StationIO {
 
   // dump to file
   void
-  dumpToFile(const eigen::DColX& bufferTime, const eigen::RTensor3& bufferFields, int bufferLine);
+  dumpToFile(const axisem3d::eigen::DColX& bufferTime,
+      const axisem3d::eigen::RTensor3& bufferFields,
+      int bufferLine);
 
   private:
   //////////////////// const ////////////////////

--- a/src/core/output/station-wise/station/Station.cpp
+++ b/src/core/output/station-wise/station/Station.cpp
@@ -13,7 +13,7 @@
 
 // set element: inplane weights and Fourier exp
 void
-Station::setElement(const eigen::DRowN& weights, int nu_1) {
+Station::setElement(const axisem3d::eigen::DRowN& weights, int nu_1) {
   // indices of non-zero weights
   mNonZeroIndices.clear();
   double rEpsilon = (double)numerical::epsilon<numerical::Real>();
@@ -42,7 +42,7 @@ Station::setElement(const eigen::DRowN& weights, int nu_1) {
 
 // rotate vector
 void
-Station::rotate(eigen::RMatX3_RM& V, int nrow, int k, double angle) {
+Station::rotate(axisem3d::eigen::RMatX3_RM& V, int nrow, int k, double angle) {
   // frame index
   int i = (k + 1 > 2) ? k - 2 : k + 1;
   int j = (k + 2 > 2) ? k - 1 : k + 2;
@@ -57,7 +57,7 @@ Station::rotate(eigen::RMatX3_RM& V, int nrow, int k, double angle) {
 
 // rotate tensor
 void
-Station::rotate(eigen::RMatX9_RM& T, int nrow, int k, double angle) {
+Station::rotate(axisem3d::eigen::RMatX9_RM& T, int nrow, int k, double angle) {
   // frame index
   int i = (k + 1 > 2) ? k - 2 : k + 1;
   int j = (k + 2 > 2) ? k - 1 : k + 2;
@@ -87,7 +87,7 @@ Station::rotate(eigen::RMatX9_RM& T, int nrow, int k, double angle) {
 // 3(5) 4(1) 5(3)
 // 6(4) 7(3) 8(2)
 void
-Station::rotate(eigen::RMatX6_RM& S, int nrow, int k, double angle) {
+Station::rotate(axisem3d::eigen::RMatX6_RM& S, int nrow, int k, double angle) {
   // voigt -> 3*3
   sTensor33.block(0, 0, nrow, 1) = S.block(0, 0, nrow, 1);
   sTensor33.block(0, 1, nrow, 1) = S.block(0, 5, nrow, 1);

--- a/src/core/output/station-wise/station/Station.hpp
+++ b/src/core/output/station-wise/station/Station.hpp
@@ -39,7 +39,7 @@ class Station {
   protected:
   // set element: inplane weights and nu
   void
-  setElement(const eigen::DRowN& weights, int nu_1);
+  setElement(const axisem3d::eigen::DRowN& weights, int nu_1);
 
   ///////////////////////// template functions /////////////////////////
   // record: inplane and Fourier interpolation
@@ -128,7 +128,7 @@ class Station {
       int bufferLine,
       int channelIndex,
       int stationIndex,
-      eigen::RTensor3& bufferFields) const {
+      axisem3d::eigen::RTensor3& bufferFields) const {
     if (fieldIndex >= 0) {
       sColBuffer.topRows(bufferLine) = field.bblk(fieldIndex);
     } else {
@@ -171,10 +171,10 @@ class Station {
     }
 
     // feed to tensor
-    eigen::IArray3 loc = {stationIndex, channelIndex, 0};
-    eigen::IArray3 len = {1, 1, bufferLine};
-    bufferFields.slice(loc, len).reshape(eigen::IArray1{bufferLine}) =
-        Eigen::TensorMap<eigen::RTensor1>(sColBuffer.data(), bufferLine);
+    axisem3d::eigen::IArray3 loc = {stationIndex, channelIndex, 0};
+    axisem3d::eigen::IArray3 len = {1, 1, bufferLine};
+    bufferFields.slice(loc, len).reshape(axisem3d::eigen::IArray1{bufferLine}) =
+        Eigen::TensorMap<axisem3d::eigen::RTensor1>(sColBuffer.data(), bufferLine);
   }
 
   ///////////////////////// data /////////////////////////
@@ -187,7 +187,7 @@ class Station {
   // inplane interpolation weights
   // NOTE: stations are likely to be located on an element edge such as
   //       the surface, so we only store non-zero inplane weights
-  eigen::RRowX mNonZeroWeights = eigen::RRowX(0);
+  axisem3d::eigen::RRowX mNonZeroWeights = axisem3d::eigen::RRowX(0);
   std::vector<int> mNonZeroIndices;
 
   // azimuth for Fourier interpolation
@@ -196,10 +196,10 @@ class Station {
   // 2 * exp(i * alpha * phi) for Fourier interpolation
 #ifndef AXISEM3D_SAVE_MEMORY
   // precompute
-  eigen::CColX m2ExpIAlphaPhi = eigen::CColX(0);
+  axisem3d::eigen::CColX m2ExpIAlphaPhi = axisem3d::eigen::CColX(0);
 #else
   // on-the-fly
-  inline static eigen::CColX s2ExpIAlphaPhi = eigen::CColX(0);
+  inline static axisem3d::eigen::CColX s2ExpIAlphaPhi = axisem3d::eigen::CColX(0);
 #endif
 
   /////////// for process ///////////
@@ -215,15 +215,15 @@ class Station {
   private:
   // rotate vector
   static void
-  rotate(eigen::RMatX3_RM& V, int nrow, int k, double angle);
+  rotate(axisem3d::eigen::RMatX3_RM& V, int nrow, int k, double angle);
 
   // rotate tensor
   static void
-  rotate(eigen::RMatX9_RM& T, int nrow, int k, double angle);
+  rotate(axisem3d::eigen::RMatX9_RM& T, int nrow, int k, double angle);
 
   // rotate tensor in Voigt
   static void
-  rotate(eigen::RMatX6_RM& S, int nrow, int k, double angle);
+  rotate(axisem3d::eigen::RMatX6_RM& S, int nrow, int k, double angle);
 
   ///////////////////////// workspace /////////////////////////
   protected:
@@ -240,8 +240,8 @@ class Station {
 
   private:
   // workspace for process
-  inline static eigen::RColX sColBuffer = eigen::RColX(0);
-  inline static eigen::RMatX9_RM sTensor33 = eigen::RMatX9_RM(0, 9);
+  inline static axisem3d::eigen::RColX sColBuffer = axisem3d::eigen::RColX(0);
+  inline static axisem3d::eigen::RMatX9_RM sTensor33 = axisem3d::eigen::RMatX9_RM(0, 9);
 };
 
 #endif /* Station_hpp */

--- a/src/core/output/station-wise/station/StationFluid.cpp
+++ b/src/core/output/station-wise/station/StationFluid.cpp
@@ -17,7 +17,7 @@
 // set element
 void
 StationFluid::setElement(
-    const std::shared_ptr<FluidElement>& element, const eigen::DRowN& weights) {
+    const std::shared_ptr<FluidElement>& element, const axisem3d::eigen::DRowN& weights) {
   // element
   mElement = element;
 
@@ -87,7 +87,7 @@ void
 StationFluid::processReport(int bufferLine,
     const channel::fluid::ChannelOptions& chops,
     int stationIndex,
-    eigen::RTensor3& bufferFields) {
+    axisem3d::eigen::RTensor3& bufferFields) {
   // rotate
   rotate(bufferLine, chops);
 

--- a/src/core/output/station-wise/station/StationFluid.hpp
+++ b/src/core/output/station-wise/station/StationFluid.hpp
@@ -26,7 +26,7 @@ class StationFluid : public Station {
   /////////////////////////// setup ///////////////////////////
   // set element
   void
-  setElement(const std::shared_ptr<FluidElement>& element, const eigen::DRowN& weights);
+  setElement(const std::shared_ptr<FluidElement>& element, const axisem3d::eigen::DRowN& weights);
 
   // set in group
   void
@@ -43,10 +43,10 @@ class StationFluid : public Station {
   std::shared_ptr<FluidElement> mElement = nullptr;
 
   // buffer
-  eigen::RMatX1_RM mBufferX = eigen::RMatX1_RM(0, 1);
-  eigen::RMatX3_RM mBufferU = eigen::RMatX3_RM(0, 3);
-  eigen::RMatX1_RM mBufferP = eigen::RMatX1_RM(0, 1);
-  eigen::RMatX1_RM mBufferD = eigen::RMatX1_RM(0, 1);
+  axisem3d::eigen::RMatX1_RM mBufferX = axisem3d::eigen::RMatX1_RM(0, 1);
+  axisem3d::eigen::RMatX3_RM mBufferU = axisem3d::eigen::RMatX3_RM(0, 3);
+  axisem3d::eigen::RMatX1_RM mBufferP = axisem3d::eigen::RMatX1_RM(0, 1);
+  axisem3d::eigen::RMatX1_RM mBufferD = axisem3d::eigen::RMatX1_RM(0, 1);
 
   /////////////////////////// process ///////////////////////////
   public:
@@ -55,7 +55,7 @@ class StationFluid : public Station {
   processReport(int bufferLine,
       const channel::fluid::ChannelOptions& chops,
       int stationIndex,
-      eigen::RTensor3& bufferFields);
+      axisem3d::eigen::RTensor3& bufferFields);
 
   private:
   // process 1: rotate
@@ -93,18 +93,18 @@ class StationFluid : public Station {
   }
 
   // workspace for record
-  inline static eigen::RRow1 sX1;
-  inline static eigen::RRow3 sU3;
-  inline static eigen::RRow1 sP1;
-  inline static eigen::RRow1 sD1;
-  inline static eigen::CMatX1 sXX1 = eigen::CMatX1(0, 1);
-  inline static eigen::CMatX3 sUX3 = eigen::CMatX3(0, 3);
-  inline static eigen::CMatX1 sPX1 = eigen::CMatX1(0, 1);
-  inline static eigen::CMatX1 sDX1 = eigen::CMatX1(0, 1);
-  inline static eigen::CMatXN sXXN1 = eigen::CMatXN(0, spectral::nPEM * 1);
-  inline static eigen::CMatXN3 sUXN3 = eigen::CMatXN3(0, spectral::nPEM * 3);
-  inline static eigen::CMatXN sPXN1 = eigen::CMatXN(0, spectral::nPEM * 1);
-  inline static eigen::CMatXN sDXN1 = eigen::CMatXN(0, spectral::nPEM * 1);
+  inline static axisem3d::eigen::RRow1 sX1;
+  inline static axisem3d::eigen::RRow3 sU3;
+  inline static axisem3d::eigen::RRow1 sP1;
+  inline static axisem3d::eigen::RRow1 sD1;
+  inline static axisem3d::eigen::CMatX1 sXX1 = axisem3d::eigen::CMatX1(0, 1);
+  inline static axisem3d::eigen::CMatX3 sUX3 = axisem3d::eigen::CMatX3(0, 3);
+  inline static axisem3d::eigen::CMatX1 sPX1 = axisem3d::eigen::CMatX1(0, 1);
+  inline static axisem3d::eigen::CMatX1 sDX1 = axisem3d::eigen::CMatX1(0, 1);
+  inline static axisem3d::eigen::CMatXN sXXN1 = axisem3d::eigen::CMatXN(0, spectral::nPEM * 1);
+  inline static axisem3d::eigen::CMatXN3 sUXN3 = axisem3d::eigen::CMatXN3(0, spectral::nPEM * 3);
+  inline static axisem3d::eigen::CMatXN sPXN1 = axisem3d::eigen::CMatXN(0, spectral::nPEM * 1);
+  inline static axisem3d::eigen::CMatXN sDXN1 = axisem3d::eigen::CMatXN(0, spectral::nPEM * 1);
 };
 
 #endif /* StationFluid_hpp */

--- a/src/core/output/station-wise/station/StationGroup.hpp
+++ b/src/core/output/station-wise/station/StationGroup.hpp
@@ -165,8 +165,8 @@ template <class StationT> class StationGroup {
 
   //////////////// non-const ////////////////
   // buffer
-  eigen::DColX mBufferTime = eigen::DColX(0);
-  eigen::RTensor3 mBufferFields = eigen::RTensor3(0, 0, 0);
+  axisem3d::eigen::DColX mBufferTime = axisem3d::eigen::DColX(0);
+  axisem3d::eigen::RTensor3 mBufferFields = axisem3d::eigen::RTensor3(0, 0, 0);
   int mBufferLine = 0;
 
   // stations

--- a/src/core/output/station-wise/station/StationSolid.cpp
+++ b/src/core/output/station-wise/station/StationSolid.cpp
@@ -17,7 +17,7 @@
 // set element
 void
 StationSolid::setElement(
-    const std::shared_ptr<SolidElement>& element, const eigen::DRowN& weights) {
+    const std::shared_ptr<SolidElement>& element, const axisem3d::eigen::DRowN& weights) {
   // element
   mElement = element;
 
@@ -96,7 +96,7 @@ void
 StationSolid::processReport(int bufferLine,
     const channel::solid::ChannelOptions& chops,
     int stationIndex,
-    eigen::RTensor3& bufferFields) {
+    axisem3d::eigen::RTensor3& bufferFields) {
   // rotate
   rotate(bufferLine, chops);
 

--- a/src/core/output/station-wise/station/StationSolid.hpp
+++ b/src/core/output/station-wise/station/StationSolid.hpp
@@ -26,7 +26,7 @@ class StationSolid : public Station {
   /////////////////////////// setup ///////////////////////////
   // set element
   void
-  setElement(const std::shared_ptr<SolidElement>& element, const eigen::DRowN& weights);
+  setElement(const std::shared_ptr<SolidElement>& element, const axisem3d::eigen::DRowN& weights);
 
   // set in group
   void
@@ -43,11 +43,11 @@ class StationSolid : public Station {
   std::shared_ptr<SolidElement> mElement = nullptr;
 
   // buffer
-  eigen::RMatX3_RM mBufferU = eigen::RMatX3_RM(0, 3);
-  eigen::RMatX9_RM mBufferG = eigen::RMatX9_RM(0, 9);
-  eigen::RMatX6_RM mBufferE = eigen::RMatX6_RM(0, 6);
-  eigen::RMatX3_RM mBufferR = eigen::RMatX3_RM(0, 3);
-  eigen::RMatX6_RM mBufferS = eigen::RMatX6_RM(0, 6);
+  axisem3d::eigen::RMatX3_RM mBufferU = axisem3d::eigen::RMatX3_RM(0, 3);
+  axisem3d::eigen::RMatX9_RM mBufferG = axisem3d::eigen::RMatX9_RM(0, 9);
+  axisem3d::eigen::RMatX6_RM mBufferE = axisem3d::eigen::RMatX6_RM(0, 6);
+  axisem3d::eigen::RMatX3_RM mBufferR = axisem3d::eigen::RMatX3_RM(0, 3);
+  axisem3d::eigen::RMatX6_RM mBufferS = axisem3d::eigen::RMatX6_RM(0, 6);
 
   /////////////////////////// process ///////////////////////////
   public:
@@ -56,7 +56,7 @@ class StationSolid : public Station {
   processReport(int bufferLine,
       const channel::solid::ChannelOptions& chops,
       int stationIndex,
-      eigen::RTensor3& bufferFields);
+      axisem3d::eigen::RTensor3& bufferFields);
 
   private:
   // process 1: rotate
@@ -99,21 +99,21 @@ class StationSolid : public Station {
   }
 
   // workspace for record
-  inline static eigen::RRow3 sU3;
-  inline static eigen::RRow9 sG9;
-  inline static eigen::RRow6 sE6;
-  inline static eigen::RRow3 sR3;
-  inline static eigen::RRow6 sS6;
-  inline static eigen::CMatX3 sUX3 = eigen::CMatX3(0, 3);
-  inline static eigen::CMatX9 sGX9 = eigen::CMatX9(0, 9);
-  inline static eigen::CMatX6 sEX6 = eigen::CMatX6(0, 6);
-  inline static eigen::CMatX3 sRX3 = eigen::CMatX3(0, 3);
-  inline static eigen::CMatX6 sSX6 = eigen::CMatX6(0, 6);
-  inline static eigen::CMatXN3 sUXN3 = eigen::CMatXN3(0, spectral::nPEM * 3);
-  inline static eigen::CMatXN9 sGXN9 = eigen::CMatXN9(0, spectral::nPEM * 9);
-  inline static eigen::CMatXN6 sEXN6 = eigen::CMatXN6(0, spectral::nPEM * 6);
-  inline static eigen::CMatXN3 sRXN3 = eigen::CMatXN3(0, spectral::nPEM * 3);
-  inline static eigen::CMatXN6 sSXN6 = eigen::CMatXN6(0, spectral::nPEM * 6);
+  inline static axisem3d::eigen::RRow3 sU3;
+  inline static axisem3d::eigen::RRow9 sG9;
+  inline static axisem3d::eigen::RRow6 sE6;
+  inline static axisem3d::eigen::RRow3 sR3;
+  inline static axisem3d::eigen::RRow6 sS6;
+  inline static axisem3d::eigen::CMatX3 sUX3 = axisem3d::eigen::CMatX3(0, 3);
+  inline static axisem3d::eigen::CMatX9 sGX9 = axisem3d::eigen::CMatX9(0, 9);
+  inline static axisem3d::eigen::CMatX6 sEX6 = axisem3d::eigen::CMatX6(0, 6);
+  inline static axisem3d::eigen::CMatX3 sRX3 = axisem3d::eigen::CMatX3(0, 3);
+  inline static axisem3d::eigen::CMatX6 sSX6 = axisem3d::eigen::CMatX6(0, 6);
+  inline static axisem3d::eigen::CMatXN3 sUXN3 = axisem3d::eigen::CMatXN3(0, spectral::nPEM * 3);
+  inline static axisem3d::eigen::CMatXN9 sGXN9 = axisem3d::eigen::CMatXN9(0, spectral::nPEM * 9);
+  inline static axisem3d::eigen::CMatXN6 sEXN6 = axisem3d::eigen::CMatXN6(0, spectral::nPEM * 6);
+  inline static axisem3d::eigen::CMatXN3 sRXN3 = axisem3d::eigen::CMatXN3(0, spectral::nPEM * 3);
+  inline static axisem3d::eigen::CMatXN6 sSXN6 = axisem3d::eigen::CMatXN6(0, spectral::nPEM * 6);
 };
 
 #endif /* StationSolid_hpp */

--- a/src/core/point/FluidPoint.cpp
+++ b/src/core/point/FluidPoint.cpp
@@ -14,7 +14,7 @@
 
 // constructor
 FluidPoint::FluidPoint(int nr,
-    const eigen::DRow2& crds,
+    const axisem3d::eigen::DRow2& crds,
     int meshTag,
     std::unique_ptr<const Mass>& mass,
     const TimeScheme& timeScheme) : Point(nr, crds, meshTag, mass) {

--- a/src/core/point/FluidPoint.hpp
+++ b/src/core/point/FluidPoint.hpp
@@ -20,7 +20,7 @@ class FluidPoint : public Point {
   public:
   // constructor
   FluidPoint(int nr,
-      const eigen::DRow2& crds,
+      const axisem3d::eigen::DRow2& crds,
       int meshTag,
       std::unique_ptr<const Mass>& mass,
       const TimeScheme& timeScheme);
@@ -62,14 +62,14 @@ class FluidPoint : public Point {
 
   // feed to mpi buffer
   void
-  feedComm(eigen::CColX& buffer, int& row) const {
+  feedComm(axisem3d::eigen::CColX& buffer, int& row) const {
     buffer.block(row, 0, mFields.mStiff.rows(), 1) = mFields.mStiff;
     row += mFields.mStiff.rows();
   }
 
   // extract from mpi buffer
   void
-  extractComm(const eigen::CColX& buffer, int& row) {
+  extractComm(const axisem3d::eigen::CColX& buffer, int& row) {
     mFields.mStiff += buffer.block(row, 0, mFields.mStiff.rows(), 1);
     row += mFields.mStiff.rows();
   }
@@ -89,7 +89,7 @@ class FluidPoint : public Point {
   // scatter displ to element
   void
   scatterDisplToElement(
-      eigen::vec_ar1_CMatPP_RM& displ, int nu_1_element, int ipol, int jpol) const {
+      axisem3d::eigen::vec_ar1_CMatPP_RM& displ, int nu_1_element, int ipol, int jpol) const {
     // copy lower orders
     for (int alpha = 0; alpha < mNu_1; alpha++) {
       displ[alpha][0](ipol, jpol) = mFields.mDispl(alpha);
@@ -104,7 +104,7 @@ class FluidPoint : public Point {
 
   // gather stiff from element
   void
-  gatherStiffFromElement(const eigen::vec_ar1_CMatPP_RM& stiff, int ipol, int jpol) {
+  gatherStiffFromElement(const axisem3d::eigen::vec_ar1_CMatPP_RM& stiff, int ipol, int jpol) {
     // add lower orders only
     for (int alpha = 0; alpha < mNu_1; alpha++) {
       mFields.mStiff(alpha) -= stiff[alpha][0](ipol, jpol);
@@ -115,12 +115,12 @@ class FluidPoint : public Point {
   // prepare pressure source
   void
   preparePressureSource() {
-    mFields.mPressureSource = eigen::CColX::Zero(mNu_1, 1);
+    mFields.mPressureSource = axisem3d::eigen::CColX::Zero(mNu_1, 1);
   }
 
   // add pressure source
   void
-  addPressureSource(const eigen::CMatXN& pressure, int nu_1_pressure, int ipnt) {
+  addPressureSource(const axisem3d::eigen::CMatXN& pressure, int nu_1_pressure, int ipnt) {
     // add minimum orders only
     int nu_1_min = std::min(mNu_1, nu_1_pressure);
     mFields.mPressureSource.topRows(nu_1_min) += pressure.block(0, ipnt, nu_1_min, 1);
@@ -132,7 +132,7 @@ class FluidPoint : public Point {
   preparePressureOutput() {
     // pressure is mAccel, which may not be allocated by the time scheme
     if (mFields.mPressureStore.rows() == 0) {
-      mFields.mPressureStore = eigen::CColX::Zero(mNu_1, 1);
+      mFields.mPressureStore = axisem3d::eigen::CColX::Zero(mNu_1, 1);
     }
   }
 
@@ -142,13 +142,13 @@ class FluidPoint : public Point {
     // delta is mStiff, but we need to store it because mStiff is set
     // to zero after dividing by mass
     if (mFields.mDeltaStore.rows() == 0) {
-      mFields.mDeltaStore = eigen::CColX::Zero(mNu_1, 1);
+      mFields.mDeltaStore = axisem3d::eigen::CColX::Zero(mNu_1, 1);
     }
   }
 
   // scatter pressure to element
   void
-  scatterPressureToElement(eigen::CMatXN& pressure, int nu_1_element, int ipnt) const {
+  scatterPressureToElement(axisem3d::eigen::CMatXN& pressure, int nu_1_element, int ipnt) const {
     // copy lower orders
     pressure.block(0, ipnt, mNu_1, 1) = mFields.mPressureStore;
 
@@ -158,7 +158,7 @@ class FluidPoint : public Point {
 
   // scatter delta to element
   void
-  scatterDeltaToElement(eigen::CMatXN& delta, int nu_1_element, int ipnt) const {
+  scatterDeltaToElement(axisem3d::eigen::CMatXN& delta, int nu_1_element, int ipnt) const {
     // copy lower orders
     delta.block(0, ipnt, mNu_1, 1) = mFields.mDeltaStore;
 
@@ -169,20 +169,20 @@ class FluidPoint : public Point {
   /////////////////////////// fields ///////////////////////////
   // fields on a fluid point
   struct Fields {
-    eigen::CColX mStiff = eigen::CColX(0, 1);
-    eigen::CColX mDispl = eigen::CColX(0, 1);
-    eigen::CColX mVeloc = eigen::CColX(0, 1);
-    eigen::CColX mAccel = eigen::CColX(0, 1);
+    axisem3d::eigen::CColX mStiff = axisem3d::eigen::CColX(0, 1);
+    axisem3d::eigen::CColX mDispl = axisem3d::eigen::CColX(0, 1);
+    axisem3d::eigen::CColX mVeloc = axisem3d::eigen::CColX(0, 1);
+    axisem3d::eigen::CColX mAccel = axisem3d::eigen::CColX(0, 1);
 
     // pressure source (to be added to accel)
-    eigen::CColX mPressureSource = eigen::CColX(0, 1);
+    axisem3d::eigen::CColX mPressureSource = axisem3d::eigen::CColX(0, 1);
 
     // acceleration storage for pressure output
     // NOTE: duplicated in Newmark
-    eigen::CColX mPressureStore = eigen::CColX(0, 1);
+    axisem3d::eigen::CColX mPressureStore = axisem3d::eigen::CColX(0, 1);
 
     // stiffness storage for delta output
-    eigen::CColX mDeltaStore = eigen::CColX(0, 1);
+    axisem3d::eigen::CColX mDeltaStore = axisem3d::eigen::CColX(0, 1);
   };
 
   // get

--- a/src/core/point/Point.hpp
+++ b/src/core/point/Point.hpp
@@ -19,7 +19,8 @@
 class Point {
   public:
   // constructor
-  Point(int nr, const eigen::DRow2& crds, int meshTag, std::unique_ptr<const Mass>& mass) :
+  Point(
+      int nr, const axisem3d::eigen::DRow2& crds, int meshTag, std::unique_ptr<const Mass>& mass) :
       mNr(nr), mNu_1(mNr / 2 + 1), mCoords(crds), mMeshTag(meshTag), mMass(mass.release()) {
     // nothing
   }
@@ -55,7 +56,7 @@ class Point {
   }
 
   // location
-  const eigen::DRow2&
+  const axisem3d::eigen::DRow2&
   getCoords() const {
     return mCoords;
   }
@@ -91,7 +92,7 @@ class Point {
   const int mNu_1;
 
   // location (s, z)
-  const eigen::DRow2 mCoords;
+  const axisem3d::eigen::DRow2 mCoords;
 
   // tag in spectral-element mesh
   // * determined by location, mpi-independent

--- a/src/core/point/SolidPoint.cpp
+++ b/src/core/point/SolidPoint.cpp
@@ -14,7 +14,7 @@
 
 // constructor
 SolidPoint::SolidPoint(int nr,
-    const eigen::DRow2& crds,
+    const axisem3d::eigen::DRow2& crds,
     int meshTag,
     std::unique_ptr<const Mass>& mass,
     const TimeScheme& timeScheme) : Point(nr, crds, meshTag, mass) {

--- a/src/core/point/SolidPoint.hpp
+++ b/src/core/point/SolidPoint.hpp
@@ -20,7 +20,7 @@ class SolidPoint : public Point {
   public:
   // constructor
   SolidPoint(int nr,
-      const eigen::DRow2& crds,
+      const axisem3d::eigen::DRow2& crds,
       int meshTag,
       std::unique_ptr<const Mass>& mass,
       const TimeScheme& timeScheme);
@@ -59,16 +59,17 @@ class SolidPoint : public Point {
 
   // feed to mpi buffer
   void
-  feedComm(eigen::CColX& buffer, int& row) const {
+  feedComm(axisem3d::eigen::CColX& buffer, int& row) const {
     buffer.block(row, 0, mFields.mStiff.size(), 1) =
-        Eigen::Map<const eigen::CColX>(mFields.mStiff.data(), mFields.mStiff.size());
+        Eigen::Map<const axisem3d::eigen::CColX>(mFields.mStiff.data(), mFields.mStiff.size());
     row += mFields.mStiff.size();
   }
 
   // extract from mpi buffer
   void
-  extractComm(const eigen::CColX& buffer, int& row) {
-    mFields.mStiff += Eigen::Map<const eigen::CMatX3>(&buffer(row), mFields.mStiff.rows(), 3);
+  extractComm(const axisem3d::eigen::CColX& buffer, int& row) {
+    mFields.mStiff +=
+        Eigen::Map<const axisem3d::eigen::CMatX3>(&buffer(row), mFields.mStiff.rows(), 3);
     row += mFields.mStiff.size();
   }
 
@@ -87,7 +88,7 @@ class SolidPoint : public Point {
   // scatter displ to element
   void
   scatterDisplToElement(
-      eigen::vec_ar3_CMatPP_RM& displ, int nu_1_element, int ipol, int jpol) const {
+      axisem3d::eigen::vec_ar3_CMatPP_RM& displ, int nu_1_element, int ipol, int jpol) const {
     // copy lower orders
     for (int alpha = 0; alpha < mNu_1; alpha++) {
       displ[alpha][0](ipol, jpol) = mFields.mDispl(alpha, 0);
@@ -106,7 +107,7 @@ class SolidPoint : public Point {
 
   // gather stiff from element
   void
-  gatherStiffFromElement(const eigen::vec_ar3_CMatPP_RM& stiff, int ipol, int jpol) {
+  gatherStiffFromElement(const axisem3d::eigen::vec_ar3_CMatPP_RM& stiff, int ipol, int jpol) {
     // add lower orders only
     for (int alpha = 0; alpha < mNu_1; alpha++) {
       mFields.mStiff(alpha, 0) -= stiff[alpha][0](ipol, jpol);
@@ -118,7 +119,7 @@ class SolidPoint : public Point {
   /////////////////////////// source ///////////////////////////
   // add force source (external)
   void
-  addForceSource(const eigen::CMatXN3& force, int nu_1_force, int ipnt) {
+  addForceSource(const axisem3d::eigen::CMatXN3& force, int nu_1_force, int ipnt) {
     // add minimum orders only
     int nu_1_min = std::min(mNu_1, nu_1_force);
     mFields.mStiff.topRows(nu_1_min) += force(Eigen::seqN(Eigen::fix<0>, nu_1_min),
@@ -128,10 +129,10 @@ class SolidPoint : public Point {
   /////////////////////////// fields ///////////////////////////
   // fields on a solid point
   struct Fields {
-    eigen::CMatX3 mStiff = eigen::CMatX3(0, 3);
-    eigen::CMatX3 mDispl = eigen::CMatX3(0, 3);
-    eigen::CMatX3 mVeloc = eigen::CMatX3(0, 3);
-    eigen::CMatX3 mAccel = eigen::CMatX3(0, 3);
+    axisem3d::eigen::CMatX3 mStiff = axisem3d::eigen::CMatX3(0, 3);
+    axisem3d::eigen::CMatX3 mDispl = axisem3d::eigen::CMatX3(0, 3);
+    axisem3d::eigen::CMatX3 mVeloc = axisem3d::eigen::CMatX3(0, 3);
+    axisem3d::eigen::CMatX3 mAccel = axisem3d::eigen::CMatX3(0, 3);
   };
 
   // get

--- a/src/core/point/eigen_point.hpp
+++ b/src/core/point/eigen_point.hpp
@@ -15,7 +15,7 @@
 #include "eigen.hpp"
 #include "numerical.hpp"
 
-namespace eigen {
+namespace axisem3d::eigen {
   // coords
   typedef Eigen::Matrix<double, 1, 2> DRow2;
 
@@ -28,6 +28,6 @@ namespace eigen {
   typedef Eigen::Matrix<double, Eigen::Dynamic, 3> DMatX3;
   typedef Eigen::Matrix<numerical::Real, Eigen::Dynamic, 3> RMatX3;
   typedef Eigen::Matrix<numerical::ComplexR, Eigen::Dynamic, 3> CMatX3;
-} // namespace eigen
+} // namespace axisem3d::eigen
 
 #endif /* eigen_point_hpp */

--- a/src/core/point/mass/Mass.hpp
+++ b/src/core/point/mass/Mass.hpp
@@ -27,11 +27,11 @@ class Mass {
 
   // compute accel in-place for fluid
   virtual void
-  computeAccel(eigen::CColX& stiff1) const = 0;
+  computeAccel(axisem3d::eigen::CColX& stiff1) const = 0;
 
   // compute accel in-place for solid
   virtual void
-  computeAccel(eigen::CMatX3& stiff3) const = 0;
+  computeAccel(axisem3d::eigen::CMatX3& stiff3) const = 0;
 };
 
 #endif /* Mass_hpp */

--- a/src/core/point/mass/Mass1D.hpp
+++ b/src/core/point/mass/Mass1D.hpp
@@ -23,13 +23,13 @@ class Mass1D : public Mass {
 
   // compute accel in-place for fluid
   void
-  computeAccel(eigen::CColX& stiff1) const {
+  computeAccel(axisem3d::eigen::CColX& stiff1) const {
     stiff1 *= mInvMass;
   }
 
   // compute accel in-place for solid
   void
-  computeAccel(eigen::CMatX3& stiff3) const {
+  computeAccel(axisem3d::eigen::CMatX3& stiff3) const {
     stiff3 *= mInvMass;
   }
 

--- a/src/core/point/mass/Mass3D.cpp
+++ b/src/core/point/mass/Mass3D.cpp
@@ -41,7 +41,7 @@ Mass3D::checkCompatibility(int nr, bool solid) const {
 
 // compute accel in-place for fluid
 void
-Mass3D::computeAccel(eigen::CColX& stiff1) const {
+Mass3D::computeAccel(axisem3d::eigen::CColX& stiff1) const {
   // constants
   int nr = (int)mInvMass.rows();
 
@@ -57,7 +57,7 @@ Mass3D::computeAccel(eigen::CColX& stiff1) const {
 
 // compute accel in-place for solid
 void
-Mass3D::computeAccel(eigen::CMatX3& stiff3) const {
+Mass3D::computeAccel(axisem3d::eigen::CMatX3& stiff3) const {
   // constants
   int nr = (int)mInvMass.rows();
 

--- a/src/core/point/mass/Mass3D.hpp
+++ b/src/core/point/mass/Mass3D.hpp
@@ -17,7 +17,8 @@
 class Mass3D : public Mass {
   public:
   // constructor
-  Mass3D(const eigen::DColX& mass) : mInvMass(mass.cwiseInverse().cast<numerical::Real>()) {
+  Mass3D(const axisem3d::eigen::DColX& mass) :
+      mInvMass(mass.cwiseInverse().cast<numerical::Real>()) {
     // nothing
   }
 
@@ -27,23 +28,23 @@ class Mass3D : public Mass {
 
   // compute accel in-place for fluid
   void
-  computeAccel(eigen::CColX& stiff1) const;
+  computeAccel(axisem3d::eigen::CColX& stiff1) const;
 
   // compute accel in-place for solid
   void
-  computeAccel(eigen::CMatX3& stiff3) const;
+  computeAccel(axisem3d::eigen::CMatX3& stiff3) const;
 
   private:
   // inverse of mass
-  const eigen::RColX mInvMass;
+  const axisem3d::eigen::RColX mInvMass;
 
   ////////////////////////////////////////
   //////////////// static ////////////////
   ////////////////////////////////////////
 
   // workspace
-  inline static eigen::RColX sStiffR1 = eigen::RColX(0);
-  inline static eigen::RMatX3 sStiffR3 = eigen::RMatX3(0, 3);
+  inline static axisem3d::eigen::RColX sStiffR1 = axisem3d::eigen::RColX(0);
+  inline static axisem3d::eigen::RMatX3 sStiffR3 = axisem3d::eigen::RMatX3(0, 3);
 };
 
 #endif /* Mass3D_hpp */

--- a/src/core/point/mass/MassOceanLoad1D.hpp
+++ b/src/core/point/mass/MassOceanLoad1D.hpp
@@ -47,7 +47,7 @@ class MassOceanLoad1D : public Mass {
 
   // compute accel in-place for fluid
   void
-  computeAccel(eigen::CColX& stiff1) const {
+  computeAccel(axisem3d::eigen::CColX& stiff1) const {
     throw std::runtime_error("MassOceanLoad1D::computeAccel || "
                              "Incompatible types: "
                              "ocean load on fluid point.");
@@ -55,7 +55,7 @@ class MassOceanLoad1D : public Mass {
 
   // compute accel in-place for solid
   void
-  computeAccel(eigen::CMatX3& stiff3) const {
+  computeAccel(axisem3d::eigen::CMatX3& stiff3) const {
     // copy s
     int nu_1 = (int)stiff3.rows();
     sStiff3_col0.topRows(nu_1) = stiff3.col(0);
@@ -88,7 +88,7 @@ class MassOceanLoad1D : public Mass {
 
   private:
   // workspace
-  inline static eigen::CColX sStiff3_col0 = eigen::CColX(0);
+  inline static axisem3d::eigen::CColX sStiff3_col0 = axisem3d::eigen::CColX(0);
 };
 
 #endif /* MassOceanLoad1D_hpp */

--- a/src/core/point/mass/MassOceanLoad3D.cpp
+++ b/src/core/point/mass/MassOceanLoad3D.cpp
@@ -24,8 +24,9 @@
 #include "fft.hpp"
 
 // constructor
-MassOceanLoad3D::MassOceanLoad3D(
-    const eigen::DColX& mass, const eigen::DColX& massOcean, const eigen::DMatX3& unitNormal) :
+MassOceanLoad3D::MassOceanLoad3D(const axisem3d::eigen::DColX& mass,
+    const axisem3d::eigen::DColX& massOcean,
+    const axisem3d::eigen::DMatX3& unitNormal) :
     mIM(mass.cwiseInverse().cast<numerical::Real>()),
     mK((massOcean.cwiseQuotient(mass.cwiseProduct(mass + massOcean)).cwiseSqrt().asDiagonal() *
         unitNormal)
@@ -63,7 +64,7 @@ MassOceanLoad3D::checkCompatibility(int nr, bool solid) const {
 
 // compute accel in-place for solid
 void
-MassOceanLoad3D::computeAccel(eigen::CMatX3& stiff3) const {
+MassOceanLoad3D::computeAccel(axisem3d::eigen::CMatX3& stiff3) const {
   // constants
   int nr = (int)mIM.rows();
 

--- a/src/core/point/mass/MassOceanLoad3D.hpp
+++ b/src/core/point/mass/MassOceanLoad3D.hpp
@@ -28,8 +28,9 @@
 class MassOceanLoad3D : public Mass {
   public:
   // constructor
-  MassOceanLoad3D(
-      const eigen::DColX& mass, const eigen::DColX& massOcean, const eigen::DMatX3& unitNormal);
+  MassOceanLoad3D(const axisem3d::eigen::DColX& mass,
+      const axisem3d::eigen::DColX& massOcean,
+      const axisem3d::eigen::DMatX3& unitNormal);
 
   // check compatibility
   void
@@ -37,7 +38,7 @@ class MassOceanLoad3D : public Mass {
 
   // compute accel in-place for fluid
   void
-  computeAccel(eigen::CColX& stiff1) const {
+  computeAccel(axisem3d::eigen::CColX& stiff1) const {
     throw std::runtime_error("MassOceanLoad3D::computeAccel || "
                              "Incompatible types: "
                              "ocean load on fluid point.");
@@ -45,13 +46,13 @@ class MassOceanLoad3D : public Mass {
 
   // compute accel in-place for solid
   void
-  computeAccel(eigen::CMatX3& stiff3) const;
+  computeAccel(axisem3d::eigen::CMatX3& stiff3) const;
 
   private:
   // im = 1 / m
-  const eigen::RColX mIM;
+  const axisem3d::eigen::RColX mIM;
   // k = sqrt(m0 / [m (m + m0)]) n
-  const eigen::RMatX3 mK;
+  const axisem3d::eigen::RMatX3 mK;
 
   ////////////////////////////////////////
   //////////////// static ////////////////
@@ -59,9 +60,9 @@ class MassOceanLoad3D : public Mass {
 
   // workspace
   // F = FFT(stiff)
-  inline static eigen::RMatX3 sF = eigen::RMatX3(0, 3);
+  inline static axisem3d::eigen::RMatX3 sF = axisem3d::eigen::RMatX3(0, 3);
   // a = im F - F.k k
-  inline static eigen::RMatX3 sA = eigen::RMatX3(0, 3);
+  inline static axisem3d::eigen::RMatX3 sA = axisem3d::eigen::RMatX3(0, 3);
 };
 
 #endif /* MassOceanLoad3D_hpp */

--- a/src/core/source/elem_src/fluid/FluidPressure.cpp
+++ b/src/core/source/elem_src/fluid/FluidPressure.cpp
@@ -15,7 +15,7 @@
 // constructor
 FluidPressure::FluidPressure(std::unique_ptr<STF>& stf,
     const std::shared_ptr<FluidElement>& element,
-    const eigen::CMatXN& pattern) : FluidSource(stf, element), mPattern(pattern) {
+    const axisem3d::eigen::CMatXN& pattern) : FluidSource(stf, element), mPattern(pattern) {
   // prepare
   element->preparePressureSource();
 

--- a/src/core/source/elem_src/fluid/FluidPressure.hpp
+++ b/src/core/source/elem_src/fluid/FluidPressure.hpp
@@ -20,7 +20,7 @@ class FluidPressure : public FluidSource {
   // constructor
   FluidPressure(std::unique_ptr<STF>& stf,
       const std::shared_ptr<FluidElement>& element,
-      const eigen::CMatXN& pattern);
+      const axisem3d::eigen::CMatXN& pattern);
 
   // apply source at a time step
   void
@@ -28,14 +28,14 @@ class FluidPressure : public FluidSource {
 
   private:
   // source pattern
-  const eigen::CMatXN mPattern;
+  const axisem3d::eigen::CMatXN mPattern;
 
   ////////////////////////////////////////
   //////////////// static ////////////////
   ////////////////////////////////////////
 
   // workspace
-  inline static eigen::CMatXN sPattern = eigen::CMatXN(0, spectral::nPEM);
+  inline static axisem3d::eigen::CMatXN sPattern = axisem3d::eigen::CMatXN(0, spectral::nPEM);
 };
 
 #endif /* FluidPressure_hpp */

--- a/src/core/source/elem_src/solid/SolidForce.cpp
+++ b/src/core/source/elem_src/solid/SolidForce.cpp
@@ -15,7 +15,7 @@
 // constructor
 SolidForce::SolidForce(std::unique_ptr<STF>& stf,
     const std::shared_ptr<SolidElement>& element,
-    const eigen::CMatXN3& pattern) : SolidSource(stf, element), mPattern(pattern) {
+    const axisem3d::eigen::CMatXN3& pattern) : SolidSource(stf, element), mPattern(pattern) {
   // prepare
   element->prepareForceSource();
 

--- a/src/core/source/elem_src/solid/SolidForce.hpp
+++ b/src/core/source/elem_src/solid/SolidForce.hpp
@@ -20,7 +20,7 @@ class SolidForce : public SolidSource {
   // constructor
   SolidForce(std::unique_ptr<STF>& stf,
       const std::shared_ptr<SolidElement>& element,
-      const eigen::CMatXN3& pattern);
+      const axisem3d::eigen::CMatXN3& pattern);
 
   // apply source at a time step
   void
@@ -28,14 +28,14 @@ class SolidForce : public SolidSource {
 
   private:
   // source pattern
-  const eigen::CMatXN3 mPattern;
+  const axisem3d::eigen::CMatXN3 mPattern;
 
   ////////////////////////////////////////
   //////////////// static ////////////////
   ////////////////////////////////////////
 
   // workspace
-  inline static eigen::CMatXN3 sPattern = eigen::CMatXN3(0, spectral::nPEM * 3);
+  inline static axisem3d::eigen::CMatXN3 sPattern = axisem3d::eigen::CMatXN3(0, spectral::nPEM * 3);
 };
 
 #endif /* SolidForce_hpp */

--- a/src/core/source/elem_src/solid/SolidMoment.cpp
+++ b/src/core/source/elem_src/solid/SolidMoment.cpp
@@ -15,7 +15,7 @@
 // constructor
 SolidMoment::SolidMoment(std::unique_ptr<STF>& stf,
     const std::shared_ptr<SolidElement>& element,
-    const eigen::CMatXN6& pattern) : SolidSource(stf, element), mPattern(pattern) {
+    const axisem3d::eigen::CMatXN6& pattern) : SolidSource(stf, element), mPattern(pattern) {
   // prepare
   element->prepareMomentSource();
 

--- a/src/core/source/elem_src/solid/SolidMoment.hpp
+++ b/src/core/source/elem_src/solid/SolidMoment.hpp
@@ -20,7 +20,7 @@ class SolidMoment : public SolidSource {
   // constructor
   SolidMoment(std::unique_ptr<STF>& stf,
       const std::shared_ptr<SolidElement>& element,
-      const eigen::CMatXN6& pattern);
+      const axisem3d::eigen::CMatXN6& pattern);
 
   // apply source at a time step
   void
@@ -28,14 +28,14 @@ class SolidMoment : public SolidSource {
 
   private:
   // source pattern
-  const eigen::CMatXN6 mPattern;
+  const axisem3d::eigen::CMatXN6 mPattern;
 
   ////////////////////////////////////////
   //////////////// static ////////////////
   ////////////////////////////////////////
 
   // workspace
-  inline static eigen::CMatXN6 sPattern = eigen::CMatXN6(0, spectral::nPEM * 6);
+  inline static axisem3d::eigen::CMatXN6 sPattern = axisem3d::eigen::CMatXN6(0, spectral::nPEM * 6);
 };
 
 #endif /* SolidMoment_hpp */

--- a/src/core/source/elem_src/stf/NetCDF_STF.cpp
+++ b/src/core/source/elem_src/stf/NetCDF_STF.cpp
@@ -73,7 +73,8 @@ NetCDF_STF::NetCDF_STF(const std::string& fileName,
   mTmax = timesAll.back();
   mVTmin = dataAll.front();
   mVTmax = dataAll.back();
-  const eigen::RColX& vals = Eigen::Map<const eigen::RColX>(dataAll.data(), dataAll.size());
+  const axisem3d::eigen::RColX& vals =
+      Eigen::Map<const axisem3d::eigen::RColX>(dataAll.data(), dataAll.size());
   mVmin = vals.minCoeff();
   mVmax = vals.maxCoeff();
 

--- a/src/core/source/elem_src/stf/StreamSTF.cpp
+++ b/src/core/source/elem_src/stf/StreamSTF.cpp
@@ -109,7 +109,8 @@ StreamSTF::verbose() const {
       4, 18, "1st (time, value)", range(mTimes.front(), (double)mData.front(), '(', ')'));
   ss << boxEquals(
       4, 18, "last (time, value)", range(mTimes.back(), (double)mData.back(), '(', ')'));
-  const eigen::RColX& d = Eigen::Map<const eigen::RColX>(mData.data(), mData.size());
+  const axisem3d::eigen::RColX& d =
+      Eigen::Map<const axisem3d::eigen::RColX>(mData.data(), mData.size());
   ss << boxEquals(4, 18, "[min, max] values", range(d.minCoeff(), d.maxCoeff()));
   // padding
   if (mPadding) {

--- a/src/core/source/injection/ElementInteriorWJ.hpp
+++ b/src/core/source/injection/ElementInteriorWJ.hpp
@@ -25,13 +25,13 @@
 #include "eigen_generic.hpp"
 #include "eigen_point.hpp"
 
-namespace eigen {
+namespace axisem3d::eigen {
   typedef Eigen::Matrix<numerical::ComplexR, 1, spectral::nPEM> CRowN;
 }
 
 template <class Element, int ndim> class ElementInteriorWJ : public Element {
   // matrix
-  typedef std::vector<std::array<eigen::CMatPP_RM, ndim>> vec_arD_CMatPP_RM;
+  typedef std::vector<std::array<axisem3d::eigen::CMatPP_RM, ndim>> vec_arD_CMatPP_RM;
 
   // stf
   typedef SourceTimeFunctionNetCDF<numerical::Real, ndim> STF_NetCDF;
@@ -67,8 +67,9 @@ template <class Element, int ndim> class ElementInteriorWJ : public Element {
     // NOTE: this will only affect interior elements
     for (int alpha = 0; alpha < this->getNu_1(); alpha++) {
       for (int idim = 0; idim < ndim; idim++) {
-        Eigen::Map<eigen::CRowN>(displElem[alpha][idim].data())(mPointsOnWJB) +=
-            Eigen::Map<const eigen::CRowN>((*mInjectedDispl)[alpha][idim].data())(mPointsOnWJB);
+        Eigen::Map<axisem3d::eigen::CRowN>(displElem[alpha][idim].data())(mPointsOnWJB) +=
+            Eigen::Map<const axisem3d::eigen::CRowN>((*mInjectedDispl)[alpha][idim].data())(
+                mPointsOnWJB);
       }
     }
   }
@@ -83,8 +84,9 @@ template <class Element, int ndim> class ElementInteriorWJ : public Element {
     // NOTE: this will also affect exterior elements
     for (int alpha = 0; alpha < this->getNu_1(); alpha++) {
       for (int idim = 0; idim < ndim; idim++) {
-        Eigen::Map<eigen::CRowN>(stiffElem[alpha][idim].data())(mPointsOnWJB) -=
-            Eigen::Map<const eigen::CRowN>(sInteriorStiff[alpha][idim].data())(mPointsOnWJB);
+        Eigen::Map<axisem3d::eigen::CRowN>(stiffElem[alpha][idim].data())(mPointsOnWJB) -=
+            Eigen::Map<const axisem3d::eigen::CRowN>(sInteriorStiff[alpha][idim].data())(
+                mPointsOnWJB);
       }
     }
 
@@ -127,7 +129,7 @@ template <class Element, int ndim> class ElementInteriorWJ : public Element {
   /////////////////////////// as a receiver ///////////////////////////
   // receiver info
   int
-  receiverInfo(std::vector<std::string>& keys, eigen::DMatXX& coords_spz) const {
+  receiverInfo(std::vector<std::string>& keys, axisem3d::eigen::DMatXX& coords_spz) const {
     // number of receivers
     int nr = this->getNr();
     int nrec = spectral::nPEM * nr;
@@ -136,7 +138,7 @@ template <class Element, int ndim> class ElementInteriorWJ : public Element {
 
     // s, z
     for (int ipnt = 0; ipnt < spectral::nPEM; ipnt++) {
-      const eigen::DRow2& sz = this->getPoint(ipnt).getCoords();
+      const axisem3d::eigen::DRow2& sz = this->getPoint(ipnt).getCoords();
       auto seq = Eigen::seqN(ipnt * nr, nr);
       coords_spz(seq, 0).fill(sz(0));
       coords_spz(seq, 2).fill(sz(1));

--- a/src/core/source/injection/WavefieldInjection.cpp
+++ b/src/core/source/injection/WavefieldInjection.cpp
@@ -248,7 +248,7 @@ WavefieldInjection::infoSolid(std::vector<std::string>& quadKeys,
     std::vector<int>& quadNrs,
     std::vector<std::vector<int>>& quadBoundaryPnts,
     std::vector<std::vector<std::string>>& recKeys,
-    std::vector<eigen::DMatXX>& rec_spz) const {
+    std::vector<axisem3d::eigen::DMatXX>& rec_spz) const {
   // size
   quadKeys.resize(mInteriorSolidElements.size());
   quadNrs.resize(mInteriorSolidElements.size());
@@ -270,7 +270,7 @@ WavefieldInjection::infoFluid(std::vector<std::string>& quadKeys,
     std::vector<int>& quadNrs,
     std::vector<std::vector<int>>& quadBoundaryPnts,
     std::vector<std::vector<std::string>>& recKeys,
-    std::vector<eigen::DMatXX>& rec_spz) const {
+    std::vector<axisem3d::eigen::DMatXX>& rec_spz) const {
   // size
   quadKeys.resize(mInteriorFluidElements.size());
   quadNrs.resize(mInteriorFluidElements.size());

--- a/src/core/source/injection/WavefieldInjection.hpp
+++ b/src/core/source/injection/WavefieldInjection.hpp
@@ -58,7 +58,7 @@ class WavefieldInjection {
       std::vector<int>& quadNrs,
       std::vector<std::vector<int>>& quadBoundaryPoints,
       std::vector<std::vector<std::string>>& recKeys,
-      std::vector<eigen::DMatXX>& rec_spz) const;
+      std::vector<axisem3d::eigen::DMatXX>& rec_spz) const;
 
   // info in fluid
   void
@@ -66,7 +66,7 @@ class WavefieldInjection {
       std::vector<int>& quadNrs,
       std::vector<std::vector<int>>& quadBoundaryPnts,
       std::vector<std::vector<std::string>>& recKeys,
-      std::vector<eigen::DMatXX>& rec_spz) const;
+      std::vector<axisem3d::eigen::DMatXX>& rec_spz) const;
 
   private:
   // elements

--- a/src/core/time/TimeScheme.cpp
+++ b/src/core/time/TimeScheme.cpp
@@ -78,7 +78,7 @@ void
 TimeScheme::reportLoopTimers(
     const std::vector<std::string>& timerNames, const std::map<std::string, SimpleTimer>& timers) {
   // collect local timers
-  eigen::DMatXX elapsed(mpi::nproc(), timerNames.size());
+  axisem3d::eigen::DMatXX elapsed(mpi::nproc(), timerNames.size());
   elapsed.setZero();
   for (int itimer = 0; itimer < timerNames.size(); itimer++) {
     elapsed(mpi::rank(), itimer) = timers.at(timerNames[itimer]).elapsedTotal();

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -42,7 +42,7 @@ main(int argc, char* argv[]) {
 
     // compute nr field
     timer::gPreloopTimer.begin("Nr(s,z) and weights", '*');
-    eigen::DColX nrWeights = computeNrFieldAndWeights(*exodusMesh);
+    axisem3d::eigen::DColX nrWeights = computeNrFieldAndWeights(*exodusMesh);
     timer::gPreloopTimer.ended("Nr(s,z) and weights", '*');
 
     const std::string loadBalanceWeight =
@@ -100,7 +100,7 @@ main(int argc, char* argv[]) {
     /////////////////////////////////////
     // Stage-II: cost-weighted domain
 
-    eigen::DColX stage2PartitionWeights;
+    axisem3d::eigen::DColX stage2PartitionWeights;
     timer::gPreloopTimer.begin("Cost measurement", '*');
     if (loadBalanceWeight == "NR") {
       timer::gPreloopTimer.message(
@@ -304,7 +304,7 @@ buildABC(const ExodusMesh& exodusMesh) {
 }
 
 // compute nr field
-eigen::DColX
+axisem3d::eigen::DColX
 computeNrFieldAndWeights(ExodusMesh& exodusMesh) {
   mpi::enterSuper();
   if (mpi::super()) {
@@ -329,7 +329,7 @@ computeNrFieldAndWeights(ExodusMesh& exodusMesh) {
   mpi::enterWorld();
 
   timer::gPreloopTimer.begin("Computing Nr-weights");
-  eigen::DColX weights;
+  axisem3d::eigen::DColX weights;
   mpi::enterSuper();
   if (mpi::super()) {
     weights = mpi::nodalToElemental(
@@ -346,7 +346,7 @@ computeNrFieldAndWeights(ExodusMesh& exodusMesh) {
 // build nr-weighted local mesh
 std::unique_ptr<LocalMesh>
 buildLocalMesh(const ExodusMesh& exodusMesh,
-    const eigen::DColX& weights,
+    const axisem3d::eigen::DColX& weights,
     const std::string& weightsKey,
     const std::string& stageKey) {
   // build
@@ -448,7 +448,7 @@ computeDt(const SE_Model& sem, const ABC& abc) {
   // get courant
   double courant = inparam::gInparamSource.getWithBounds("time_axis:Courant_number", 0.0);
   // automatically determined by mesh
-  eigen::DCol2 sz;
+  axisem3d::eigen::DCol2 sz;
   double dtMesh = sem.computeDt(courant, abc, sz);
   // enforced
   double dtEnforce =
@@ -574,7 +574,7 @@ initalizeFFT(const std::string& stageKey) {
 }
 
 // measure cost
-eigen::DColX
+axisem3d::eigen::DColX
 measureCost(const SE_Model& sem,
     const ExodusMesh& exodusMesh,
     const LocalMesh& localMesh,

--- a/src/main.hpp
+++ b/src/main.hpp
@@ -62,13 +62,13 @@ std::unique_ptr<const ABC>
 buildABC(const ExodusMesh& exodusMesh);
 
 // compute nr field and weights
-eigen::DColX
+axisem3d::eigen::DColX
 computeNrFieldAndWeights(ExodusMesh& exodusMesh);
 
 // build nr-weighted local mesh
 std::unique_ptr<LocalMesh>
 buildLocalMesh(const ExodusMesh& exodusMesh,
-    const eigen::DColX& weights,
+    const axisem3d::eigen::DColX& weights,
     const std::string& weightsKey,
     const std::string& stageKey);
 
@@ -115,7 +115,7 @@ void
 initalizeFFT(const std::string& stageKey);
 
 // measure cost
-eigen::DColX
+axisem3d::eigen::DColX
 measureCost(const SE_Model& sem,
     const ExodusMesh& exodusMesh,
     const LocalMesh& localMesh,

--- a/src/models3D/Model3D.cpp
+++ b/src/models3D/Model3D.cpp
@@ -14,14 +14,14 @@
 #include "vicinity.hpp"
 
 // compute spz on element
-eigen::DMatX3
+axisem3d::eigen::DMatX3
 Model3D::computeElemSPZ(const Quad& quad, bool undulated) {
   // quad nr
-  const eigen::IRowN& pointNr = quad.getPointNr();
+  const axisem3d::eigen::IRowN& pointNr = quad.getPointNr();
   // GLL coordinates
-  const eigen::DMat2N& pointSZ = quad.getPointSZ();
+  const axisem3d::eigen::DMat2N& pointSZ = quad.getPointSZ();
   // allocate
-  eigen::DMatX3 spz(pointNr.sum(), 3);
+  axisem3d::eigen::DMatX3 spz(pointNr.sum(), 3);
   // structured to flattened
   int row = 0;
   for (int ipnt = 0; ipnt < spectral::nPEM; ipnt++) {
@@ -30,7 +30,8 @@ Model3D::computeElemSPZ(const Quad& quad, bool undulated) {
     spz.block(row, 0, nr, 1).fill(pointSZ(0, ipnt));
     spz.block(row, 2, nr, 1).fill(pointSZ(1, ipnt));
     // linearly varying phi
-    spz.block(row, 1, nr, 1) = eigen::DColX::LinSpaced(nr, 0, 2. * numerical::dPi / nr * (nr - 1));
+    spz.block(row, 1, nr, 1) =
+        axisem3d::eigen::DColX::LinSpaced(nr, 0, 2. * numerical::dPi / nr * (nr - 1));
     row += nr;
   }
 
@@ -39,7 +40,7 @@ Model3D::computeElemSPZ(const Quad& quad, bool undulated) {
     return spz;
   }
   // get undulation from quad
-  eigen::arN_DColX und = quad.getUndulation();
+  axisem3d::eigen::arN_DColX und = quad.getUndulation();
   // structured to flattened
   row = 0;
   for (int ipnt = 0; ipnt < spectral::nPEM; ipnt++) {
@@ -67,16 +68,16 @@ Model3D::computeElemSPZ(const Quad& quad, bool undulated) {
 }
 
 // compute spz on edge
-eigen::DMatX3
+axisem3d::eigen::DMatX3
 Model3D::computeEdgeSPZ(const Quad& quad, int edge) {
   // edge points
   const std::vector<int>& ipnts = vicinity::constants::gEdgeIPnt[edge];
   // quad nr
-  const eigen::IRowN& pointNr = quad.getPointNr();
+  const axisem3d::eigen::IRowN& pointNr = quad.getPointNr();
   // GLL coordinates
-  const eigen::DMat2N& pointSZ = quad.getPointSZ();
+  const axisem3d::eigen::DMat2N& pointSZ = quad.getPointSZ();
   // allocate
-  eigen::DMatX3 spz(pointNr(ipnts).sum(), 3);
+  axisem3d::eigen::DMatX3 spz(pointNr(ipnts).sum(), 3);
   // structured to flattened
   int row = 0;
   for (int ipnt : ipnts) {
@@ -85,7 +86,8 @@ Model3D::computeEdgeSPZ(const Quad& quad, int edge) {
     spz.block(row, 0, nr, 1).fill(pointSZ(0, ipnt));
     spz.block(row, 2, nr, 1).fill(pointSZ(1, ipnt));
     // linearly varying phi
-    spz.block(row, 1, nr, 1) = eigen::DColX::LinSpaced(nr, 0, 2. * numerical::dPi / nr * (nr - 1));
+    spz.block(row, 1, nr, 1) =
+        axisem3d::eigen::DColX::LinSpaced(nr, 0, 2. * numerical::dPi / nr * (nr - 1));
     row += nr;
   }
   return spz;

--- a/src/models3D/Model3D.hpp
+++ b/src/models3D/Model3D.hpp
@@ -62,11 +62,11 @@ class Model3D {
 
   ////////////////////////////// static //////////////////////////////
   // compute spz on element
-  static eigen::DMatX3
+  static axisem3d::eigen::DMatX3
   computeElemSPZ(const Quad& quad, bool undulated = false);
 
   // compute spz on edge
-  static eigen::DMatX3
+  static axisem3d::eigen::DMatX3
   computeEdgeSPZ(const Quad& quad, int edge);
 
   // check inplane scope
@@ -117,8 +117,8 @@ class Model3D {
   }
 
   // compute coords in model CS
-  static eigen::DMatX3
-  coordsFromMeshToModel(const eigen::DMatX3& spzMesh,
+  static axisem3d::eigen::DMatX3
+  coordsFromMeshToModel(const axisem3d::eigen::DMatX3& spzMesh,
       bool sourceCentered,
       bool xy,
       bool ellipticity,
@@ -126,7 +126,7 @@ class Model3D {
       bool useDepth,
       bool depthSolid,
       const std::string& modelName) {
-    eigen::DMatX3 crdModel;
+    axisem3d::eigen::DMatX3 crdModel;
     if (sourceCentered) {
       if (geodesy::isCartesian()) {
         crdModel = spzMesh;
@@ -155,7 +155,7 @@ class Model3D {
                                    "Model name = " +
               modelName);
         }
-        eigen::DMatX3 spzBend(spzMesh.rows(), spzMesh.cols());
+        axisem3d::eigen::DMatX3 spzBend(spzMesh.rows(), spzMesh.cols());
         const auto& t = spzMesh.col(0).cwiseQuotient(spzMesh.col(2));
         spzBend.col(0) = spzMesh.col(2).array() * t.array().sin();
         spzBend.col(2) = spzMesh.col(2).array() * t.array().cos();

--- a/src/models3D/geometric/Ellipticity.cpp
+++ b/src/models3D/geometric/Ellipticity.cpp
@@ -14,14 +14,15 @@
 
 // get undulation on points
 bool
-Ellipticity::getUndulation(const eigen::DMatX3& spz, eigen::DColX& undulation) const {
+Ellipticity::getUndulation(
+    const axisem3d::eigen::DMatX3& spz, axisem3d::eigen::DColX& undulation) const {
   if (geodesy::isCartesian() || geodesy::getOuterFlattening() < numerical::dEpsilon) {
     return false;
   }
   // theta, phi, r
-  const eigen::DMatX3& llr =
+  const axisem3d::eigen::DMatX3& llr =
       coordsFromMeshToModel(spz, false, false, false, false, false, false, mModelName);
-  const eigen::DMatX3& tpr = geodesy::llr2tpr(llr, false);
+  const axisem3d::eigen::DMatX3& tpr = geodesy::llr2tpr(llr, false);
   // flattening
   typedef Eigen::Array<double, Eigen::Dynamic, 1> DColX_Array;
   const DColX_Array& r = tpr.col(2);

--- a/src/models3D/geometric/Ellipticity.hpp
+++ b/src/models3D/geometric/Ellipticity.hpp
@@ -24,7 +24,7 @@ class Ellipticity : public Geometric3D {
   private:
   // get undulation on points
   bool
-  getUndulation(const eigen::DMatX3& spz, eigen::DColX& undulation) const;
+  getUndulation(const axisem3d::eigen::DMatX3& spz, axisem3d::eigen::DColX& undulation) const;
 
   // verbose
   std::string

--- a/src/models3D/geometric/Geometric3D.cpp
+++ b/src/models3D/geometric/Geometric3D.cpp
@@ -19,9 +19,9 @@ Geometric3D::applyTo(std::vector<Quad>& quads) const {
   if (!isSuperOnly()) {
     for (Quad& quad : quads) {
       // cardinal coordinates
-      const eigen::DMatX3& spz = computeElemSPZ(quad);
+      const axisem3d::eigen::DMatX3& spz = computeElemSPZ(quad);
       // compute values
-      eigen::DColX und;
+      axisem3d::eigen::DColX und;
       bool elemInScope = getUndulation(spz, quad.getNodalSZ(), und);
       // set values to quad
       if (elemInScope) {
@@ -32,8 +32,8 @@ Geometric3D::applyTo(std::vector<Quad>& quads) const {
     mpi::enterInfer();
     for (int irank = 0; irank < mpi::nproc(); irank++) {
       // step 1: gather coords on infer and send to super
-      std::vector<eigen::DMatX3> spzAll;
-      std::vector<eigen::DMat24> szAll;
+      std::vector<axisem3d::eigen::DMatX3> spzAll;
+      std::vector<axisem3d::eigen::DMat24> szAll;
       if (irank == mpi::rank()) {
         // gather coords
         spzAll.reserve(quads.size());
@@ -48,8 +48,8 @@ Geometric3D::applyTo(std::vector<Quad>& quads) const {
       }
 
       // step 2: compute values on super and send back to infer
-      std::vector<eigen::DColX> undAll;
-      std::vector<eigen::IColX> elemInScopeAll;
+      std::vector<axisem3d::eigen::DColX> undAll;
+      std::vector<axisem3d::eigen::IColX> elemInScopeAll;
       if (mpi::root()) {
         // recv coords from infer
         mpi::recvVecEigen(irank, spzAll, 0);
@@ -57,10 +57,10 @@ Geometric3D::applyTo(std::vector<Quad>& quads) const {
         // allocate values
         int nQuad = (int)spzAll.size();
         undAll.reserve(nQuad);
-        elemInScopeAll.push_back(eigen::IColX::Zero(nQuad));
+        elemInScopeAll.push_back(axisem3d::eigen::IColX::Zero(nQuad));
         // compute values
         for (int iq = 0; iq < nQuad; iq++) {
-          eigen::DColX und;
+          axisem3d::eigen::DColX und;
           elemInScopeAll[0](iq) = getUndulation(spzAll[iq], szAll[iq], und);
           undAll.push_back(und);
         }
@@ -90,10 +90,10 @@ Geometric3D::applyTo(std::vector<Quad>& quads) const {
 
 // set undulation to quad
 void
-Geometric3D::setUndulationToQuad(const eigen::DColX& undulation, Quad& quad) const {
+Geometric3D::setUndulationToQuad(const axisem3d::eigen::DColX& undulation, Quad& quad) const {
   // flattened to structured
-  const eigen::IRowN& pointNr = quad.getPointNr();
-  eigen::arN_DColX undArr;
+  const axisem3d::eigen::IRowN& pointNr = quad.getPointNr();
+  axisem3d::eigen::arN_DColX undArr;
   int row = 0;
   for (int ipnt = 0; ipnt < spectral::nPEM; ipnt++) {
     int nr = pointNr(ipnt);

--- a/src/models3D/geometric/Geometric3D.hpp
+++ b/src/models3D/geometric/Geometric3D.hpp
@@ -31,20 +31,21 @@ class Geometric3D : public Model3D {
   protected:
   // get undulation on an element
   virtual bool
-  getUndulation(
-      const eigen::DMatX3& spz, const eigen::DMat24& nodalSZ, eigen::DColX& undulation) const {
+  getUndulation(const axisem3d::eigen::DMatX3& spz,
+      const axisem3d::eigen::DMat24& nodalSZ,
+      axisem3d::eigen::DColX& undulation) const {
     // no element check by virtual
     return getUndulation(spz, undulation);
   }
 
   // set undulation to quad
   virtual void
-  setUndulationToQuad(const eigen::DColX& undulation, Quad& quad) const;
+  setUndulationToQuad(const axisem3d::eigen::DColX& undulation, Quad& quad) const;
 
   public:
   // get undulation on points
   virtual bool
-  getUndulation(const eigen::DMatX3& spz, eigen::DColX& undulation) const = 0;
+  getUndulation(const axisem3d::eigen::DMatX3& spz, axisem3d::eigen::DColX& undulation) const = 0;
 
   ////////////////////////////// static //////////////////////////////
   public:

--- a/src/models3D/geometric/StructuredGridG3D.cpp
+++ b/src/models3D/geometric/StructuredGridG3D.cpp
@@ -68,8 +68,9 @@ StructuredGridG3D::StructuredGridG3D(const std::string& modelName,
 
 // get undulation on an element
 bool
-StructuredGridG3D::getUndulation(
-    const eigen::DMatX3& spz, const eigen::DMat24& nodalSZ, eigen::DColX& undulation) const {
+StructuredGridG3D::getUndulation(const axisem3d::eigen::DMatX3& spz,
+    const axisem3d::eigen::DMat24& nodalSZ,
+    axisem3d::eigen::DColX& undulation) const {
   // check inplane scope
   const auto& gridCrds = mGrid->getGridCoords();
   if (!inplaneScope(nodalSZ,
@@ -88,7 +89,8 @@ StructuredGridG3D::getUndulation(
 
 // get undulation on points
 bool
-StructuredGridG3D::getUndulation(const eigen::DMatX3& spz, eigen::DColX& undulation) const {
+StructuredGridG3D::getUndulation(
+    const axisem3d::eigen::DMatX3& spz, axisem3d::eigen::DColX& undulation) const {
   // cannot use undulated geometry to locate source and receivers
   // for super-only storage
   if (mGrid == nullptr) {
@@ -100,13 +102,13 @@ StructuredGridG3D::getUndulation(const eigen::DMatX3& spz, eigen::DColX& undulat
 
   //////////////////////// coords ////////////////////////
   // compute grid coords
-  const eigen::DMatX3& crdGrid = coordsFromMeshToModel(
+  const axisem3d::eigen::DMatX3& crdGrid = coordsFromMeshToModel(
       spz, mSourceCentered, mXY, mEllipticity, mLon360, mUseDepth, mDepthSolid, mModelName);
 
   //////////////////////// values ////////////////////////
   // allocate and fill with zero
   int nCardinals = (int)spz.rows();
-  undulation = eigen::DColX::Zero(nCardinals);
+  undulation = axisem3d::eigen::DColX::Zero(nCardinals);
 
   // point loop
   static const double err = std::numeric_limits<double>::lowest();
@@ -118,7 +120,7 @@ StructuredGridG3D::getUndulation(const eigen::DMatX3& spz, eigen::DColX& undulat
       continue;
     }
     // horizontal interpolation
-    const eigen::DRow2& horizontal = crdGrid.block(ipnt, 0, 1, 2);
+    const axisem3d::eigen::DRow2& horizontal = crdGrid.block(ipnt, 0, 1, 2);
     double val = mGrid->compute(horizontal, err);
     // check horizontal scope
     if (val > err * .9) {

--- a/src/models3D/geometric/StructuredGridG3D.hpp
+++ b/src/models3D/geometric/StructuredGridG3D.hpp
@@ -39,12 +39,13 @@ class StructuredGridG3D : public Geometric3D {
   private:
   // get undulation on an element
   bool
-  getUndulation(
-      const eigen::DMatX3& spz, const eigen::DMat24& nodalSZ, eigen::DColX& undulation) const;
+  getUndulation(const axisem3d::eigen::DMatX3& spz,
+      const axisem3d::eigen::DMat24& nodalSZ,
+      axisem3d::eigen::DColX& undulation) const;
 
   // get undulation on points
   bool
-  getUndulation(const eigen::DMatX3& spz, eigen::DColX& undulation) const;
+  getUndulation(const axisem3d::eigen::DMatX3& spz, axisem3d::eigen::DColX& undulation) const;
 
   // verbose
   std::string

--- a/src/models3D/ocean_load/OceanLoad3D.cpp
+++ b/src/models3D/ocean_load/OceanLoad3D.cpp
@@ -25,9 +25,9 @@ OceanLoad3D::applyTo(std::vector<Quad>& quads) const {
         continue;
       }
       // cardinal coordinates
-      const eigen::DMatX3& spz = computeEdgeSPZ(quad, surfEdge);
+      const axisem3d::eigen::DMatX3& spz = computeEdgeSPZ(quad, surfEdge);
       // compute values
-      eigen::DColX sumRD;
+      axisem3d::eigen::DColX sumRD;
       bool elemInScope = getSumRhoDepth(spz, quad.getNodalSZ(), sumRD);
       // set values to quad
       if (elemInScope) {
@@ -38,8 +38,8 @@ OceanLoad3D::applyTo(std::vector<Quad>& quads) const {
     mpi::enterInfer();
     for (int irank = 0; irank < mpi::nproc(); irank++) {
       // step 1: gather coords on infer and send to super
-      std::vector<eigen::DMatX3> spzAll;
-      std::vector<eigen::DMat24> szAll;
+      std::vector<axisem3d::eigen::DMatX3> spzAll;
+      std::vector<axisem3d::eigen::DMat24> szAll;
       if (irank == mpi::rank()) {
         // gather coords
         // spzAll.reserve(quads.size());
@@ -59,8 +59,8 @@ OceanLoad3D::applyTo(std::vector<Quad>& quads) const {
       }
 
       // step 2: compute values on super and send back to infer
-      std::vector<eigen::DColX> sumRD_All;
-      std::vector<eigen::IColX> elemInScopeAll;
+      std::vector<axisem3d::eigen::DColX> sumRD_All;
+      std::vector<axisem3d::eigen::IColX> elemInScopeAll;
       if (mpi::root()) {
         // recv coords from infer
         mpi::recvVecEigen(irank, spzAll, 0);
@@ -68,10 +68,10 @@ OceanLoad3D::applyTo(std::vector<Quad>& quads) const {
         // allocate values
         int nQuad = (int)spzAll.size();
         sumRD_All.reserve(nQuad);
-        elemInScopeAll.push_back(eigen::IColX::Zero(nQuad));
+        elemInScopeAll.push_back(axisem3d::eigen::IColX::Zero(nQuad));
         // compute values
         for (int iq = 0; iq < nQuad; iq++) {
-          eigen::DColX sumRD;
+          axisem3d::eigen::DColX sumRD;
           elemInScopeAll[0](iq) = getSumRhoDepth(spzAll[iq], szAll[iq], sumRD);
           sumRD_All.push_back(sumRD);
         }
@@ -108,13 +108,13 @@ OceanLoad3D::applyTo(std::vector<Quad>& quads) const {
 
 // set sum(rho * depth) to quad
 void
-OceanLoad3D::setSumRhoDepthToQuad(const eigen::DColX& sumRhoDepth, Quad& quad) const {
+OceanLoad3D::setSumRhoDepthToQuad(const axisem3d::eigen::DColX& sumRhoDepth, Quad& quad) const {
   // edge points
   int surfEdge = quad.getSurfaceEdge();
   const std::vector<int>& ipnts = vicinity::constants::gEdgeIPnt[surfEdge];
-  const eigen::IRowN& pointNr = quad.getPointNr();
+  const axisem3d::eigen::IRowN& pointNr = quad.getPointNr();
   // flattened to structured
-  eigen::arP_DColX sumRD;
+  axisem3d::eigen::arP_DColX sumRD;
   int row = 0;
   for (int ip = 0; ip < spectral::nPED; ip++) {
     int nr = pointNr(ipnts[ip]);

--- a/src/models3D/ocean_load/OceanLoad3D.hpp
+++ b/src/models3D/ocean_load/OceanLoad3D.hpp
@@ -31,12 +31,13 @@ class OceanLoad3D : public Model3D {
   protected:
   // get sum(rho * depth)
   virtual bool
-  getSumRhoDepth(
-      const eigen::DMatX3& spz, const eigen::DMat24& nodalSZ, eigen::DColX& sumRhoDepth) const = 0;
+  getSumRhoDepth(const axisem3d::eigen::DMatX3& spz,
+      const axisem3d::eigen::DMat24& nodalSZ,
+      axisem3d::eigen::DColX& sumRhoDepth) const = 0;
 
   // set sum(rho * depth) to quad
   virtual void
-  setSumRhoDepthToQuad(const eigen::DColX& sumRhoDepth, Quad& quad) const;
+  setSumRhoDepthToQuad(const axisem3d::eigen::DColX& sumRhoDepth, Quad& quad) const;
 
   ////////////////////////////// static //////////////////////////////
   public:

--- a/src/models3D/ocean_load/StructuredGridO3D.cpp
+++ b/src/models3D/ocean_load/StructuredGridO3D.cpp
@@ -62,8 +62,9 @@ StructuredGridO3D::StructuredGridO3D(const std::string& modelName,
 
 // get sum(rho * depth)
 bool
-StructuredGridO3D::getSumRhoDepth(
-    const eigen::DMatX3& spz, const eigen::DMat24& nodalSZ, eigen::DColX& sumRhoDepth) const {
+StructuredGridO3D::getSumRhoDepth(const axisem3d::eigen::DMatX3& spz,
+    const axisem3d::eigen::DMat24& nodalSZ,
+    axisem3d::eigen::DColX& sumRhoDepth) const {
   //////////////////////// coords ////////////////////////
   // check min/max
   const auto& gridCrds = mGrid->getGridCoords();
@@ -80,19 +81,19 @@ StructuredGridO3D::getSumRhoDepth(
   }
 
   // compute grid coords
-  const eigen::DMatX3& crdGrid = coordsFromMeshToModel(
+  const axisem3d::eigen::DMatX3& crdGrid = coordsFromMeshToModel(
       spz, mSourceCentered, mXY, mEllipticity, mLon360, false, false, mModelName);
 
   //////////////////////// values ////////////////////////
   // allocate and fill with zero
   int nCardinals = (int)spz.rows();
-  sumRhoDepth = eigen::DColX::Zero(nCardinals);
+  sumRhoDepth = axisem3d::eigen::DColX::Zero(nCardinals);
 
   // point loop
   static const double err = std::numeric_limits<double>::lowest();
   bool oneInScope = false;
   for (int ipnt = 0; ipnt < nCardinals; ipnt++) {
-    const eigen::DRow2& horizontal = crdGrid.block(ipnt, 0, 1, 2);
+    const axisem3d::eigen::DRow2& horizontal = crdGrid.block(ipnt, 0, 1, 2);
     double val = mGrid->compute(horizontal, err);
     // check scope
     // ignore negative sum(rho * depth)

--- a/src/models3D/ocean_load/StructuredGridO3D.hpp
+++ b/src/models3D/ocean_load/StructuredGridO3D.hpp
@@ -34,8 +34,9 @@ class StructuredGridO3D : public OceanLoad3D {
   private:
   // get sum(rho * depth)
   bool
-  getSumRhoDepth(
-      const eigen::DMatX3& spz, const eigen::DMat24& nodalSZ, eigen::DColX& sumRhoDepth) const;
+  getSumRhoDepth(const axisem3d::eigen::DMatX3& spz,
+      const axisem3d::eigen::DMat24& nodalSZ,
+      axisem3d::eigen::DColX& sumRhoDepth) const;
 
   // verbose
   std::string

--- a/src/models3D/volumetric/StructuredGridV3D.cpp
+++ b/src/models3D/volumetric/StructuredGridV3D.cpp
@@ -83,7 +83,7 @@ StructuredGridV3D::StructuredGridV3D(const std::string& modelName,
           "C55",
           "C56",
           "C66"};
-      mIndexCIJ = std::make_unique<eigen::IMat66>();
+      mIndexCIJ = std::make_unique<axisem3d::eigen::IMat66>();
       for (const std::string& CIJ : allCIJ) {
         auto it = std::find(mPropertyKeys.begin(), mPropertyKeys.end(), CIJ);
         if (it == mPropertyKeys.end()) {
@@ -149,15 +149,15 @@ StructuredGridV3D::getPropertyInfo(
 
 // get properties
 bool
-StructuredGridV3D::getProperties(const eigen::DMatX3& spz,
-    const eigen::DMat24& nodalSZ,
-    eigen::IMatXX& inScopes,
-    eigen::DMatXX& propValues) const {
+StructuredGridV3D::getProperties(const axisem3d::eigen::DMatX3& spz,
+    const axisem3d::eigen::DMat24& nodalSZ,
+    axisem3d::eigen::IMatXX& inScopes,
+    axisem3d::eigen::DMatXX& propValues) const {
   //////////////////////// coords ////////////////////////
   // check center
   const auto& gridCrds = mGrid->getGridCoords();
   if (mElementCenter) {
-    if (!inplaneScope<eigen::DCol2>(nodalSZ.rowwise().mean(),
+    if (!inplaneScope<axisem3d::eigen::DCol2>(nodalSZ.rowwise().mean(),
             mSourceCentered && (!mXY),
             gridCrds[0].front(),
             gridCrds[0].back(),
@@ -184,22 +184,22 @@ StructuredGridV3D::getProperties(const eigen::DMatX3& spz,
   }
 
   // compute grid coords
-  eigen::DMatX3 crdGrid = coordsFromMeshToModel(
+  axisem3d::eigen::DMatX3 crdGrid = coordsFromMeshToModel(
       spz, mSourceCentered, mXY, mEllipticity, mLon360, mUseDepth, mDepthSolid, mModelName);
 
   //////////////////////// values ////////////////////////
   // allocate
   int nProperties = (int)mPropertyKeys.size();
   int nCardinals = (int)spz.rows();
-  inScopes = eigen::IMatXX::Zero(nCardinals, nProperties);
-  propValues = eigen::DMatXX::Zero(nCardinals, nProperties);
+  inScopes = axisem3d::eigen::IMatXX::Zero(nCardinals, nProperties);
+  propValues = axisem3d::eigen::DMatXX::Zero(nCardinals, nProperties);
 
   // point loop
   static const double err = std::numeric_limits<double>::lowest();
-  const eigen::DRowX& valOut = eigen::DRowX::Constant(nProperties, err);
+  const axisem3d::eigen::DRowX& valOut = axisem3d::eigen::DRowX::Constant(nProperties, err);
   for (int ipnt = 0; ipnt < nCardinals; ipnt++) {
     int dimOutOfRange = 0;
-    const eigen::DRowX& val = mGrid->compute(crdGrid.row(ipnt), valOut, dimOutOfRange);
+    const axisem3d::eigen::DRowX& val = mGrid->compute(crdGrid.row(ipnt), valOut, dimOutOfRange);
     // check scope
     if (val(0) > err * .9) {
       inScopes.row(ipnt).fill(1);
@@ -221,7 +221,7 @@ StructuredGridV3D::getProperties(const eigen::DMatX3& spz,
 
   // rotate Cijkl
   if (mIndexCIJ && ((!mSourceCentered) || mXY)) {
-    eigen::DColX angle;
+    axisem3d::eigen::DColX angle;
     if (!mSourceCentered) {
       // geographic: rotate around vertical by -baz
       // depth back to radius
@@ -238,7 +238,7 @@ StructuredGridV3D::getProperties(const eigen::DMatX3& spz,
 
     // point loop
     for (int ipnt = 0; ipnt < nCardinals; ipnt++) {
-      static eigen::DMat66 inCijkl, outCijkl;
+      static axisem3d::eigen::DMat66 inCijkl, outCijkl;
       // copy input
       for (int i = 0; i < 6; i++) {
         for (int j = 0; j < 6; j++) {

--- a/src/models3D/volumetric/StructuredGridV3D.hpp
+++ b/src/models3D/volumetric/StructuredGridV3D.hpp
@@ -47,10 +47,10 @@ class StructuredGridV3D : public Volumetric3D {
 
   // get properties
   bool
-  getProperties(const eigen::DMatX3& spz,
-      const eigen::DMat24& nodalSZ,
-      eigen::IMatXX& inScopes,
-      eigen::DMatXX& propValues) const;
+  getProperties(const axisem3d::eigen::DMatX3& spz,
+      const axisem3d::eigen::DMat24& nodalSZ,
+      axisem3d::eigen::IMatXX& inScopes,
+      axisem3d::eigen::DMatXX& propValues) const;
 
   // verbose
   std::string
@@ -87,7 +87,7 @@ class StructuredGridV3D : public Volumetric3D {
   std::vector<std::string> mPropertyVarNames;
   std::vector<double> mPropertyFactors;
   std::vector<ReferenceKind> mPropertyReferenceKinds;
-  std::unique_ptr<eigen::IMat66> mIndexCIJ;
+  std::unique_ptr<axisem3d::eigen::IMat66> mIndexCIJ;
 
   // grid
   std::unique_ptr<StructuredGrid<3, double>> mGrid = nullptr;

--- a/src/models3D/volumetric/Volumetric3D.cpp
+++ b/src/models3D/volumetric/Volumetric3D.cpp
@@ -26,10 +26,10 @@ Volumetric3D::applyTo(std::vector<Quad>& quads) const {
   if (!isSuperOnly()) {
     for (Quad& quad : quads) {
       // cardinal coordinates
-      const eigen::DMatX3& spz = computeElemSPZ(quad, usingUndulatedGeometry());
+      const axisem3d::eigen::DMatX3& spz = computeElemSPZ(quad, usingUndulatedGeometry());
       // compute values
-      eigen::IMatXX inScopes;
-      eigen::DMatXX propValues;
+      axisem3d::eigen::IMatXX inScopes;
+      axisem3d::eigen::DMatXX propValues;
       bool elemInScope = getProperties(spz, quad.getNodalSZ(), inScopes, propValues);
       // set values to quad
       if (elemInScope) {
@@ -40,8 +40,8 @@ Volumetric3D::applyTo(std::vector<Quad>& quads) const {
     mpi::enterInfer();
     for (int irank = 0; irank < mpi::nproc(); irank++) {
       // step 1: gather coords on infer and send to super
-      std::vector<eigen::DMatX3> spzAll;
-      std::vector<eigen::DMat24> szAll;
+      std::vector<axisem3d::eigen::DMatX3> spzAll;
+      std::vector<axisem3d::eigen::DMat24> szAll;
       if (irank == mpi::rank()) {
         // gather coords
         spzAll.reserve(quads.size());
@@ -56,9 +56,9 @@ Volumetric3D::applyTo(std::vector<Quad>& quads) const {
       }
 
       // step 2: compute values on super and send back to infer
-      std::vector<eigen::IMatXX> inScopesAll;
-      std::vector<eigen::DMatXX> propValuesAll;
-      std::vector<eigen::IColX> elemInScopeAll;
+      std::vector<axisem3d::eigen::IMatXX> inScopesAll;
+      std::vector<axisem3d::eigen::DMatXX> propValuesAll;
+      std::vector<axisem3d::eigen::IColX> elemInScopeAll;
       if (mpi::root()) {
         // recv coords from infer
         mpi::recvVecEigen(irank, spzAll, 0);
@@ -67,11 +67,11 @@ Volumetric3D::applyTo(std::vector<Quad>& quads) const {
         int nQuad = (int)spzAll.size();
         inScopesAll.reserve(nQuad);
         propValuesAll.reserve(nQuad);
-        elemInScopeAll.push_back(eigen::IColX::Zero(nQuad));
+        elemInScopeAll.push_back(axisem3d::eigen::IColX::Zero(nQuad));
         // compute values
         for (int iq = 0; iq < nQuad; iq++) {
-          eigen::IMatXX inScopes;
-          eigen::DMatXX propValues;
+          axisem3d::eigen::IMatXX inScopes;
+          axisem3d::eigen::DMatXX propValues;
           elemInScopeAll[0](iq) = getProperties(spzAll[iq], szAll[iq], inScopes, propValues);
           inScopesAll.push_back(inScopes);
           propValuesAll.push_back(propValues);
@@ -107,16 +107,16 @@ Volumetric3D::applyTo(std::vector<Quad>& quads) const {
 void
 Volumetric3D::setPropertiesToQuad(const std::vector<std::string>& propKeys,
     const std::vector<ReferenceKind>& refKinds,
-    const eigen::IMatXX& inScopes,
-    const eigen::DMatXX& propValues,
+    const axisem3d::eigen::IMatXX& inScopes,
+    const axisem3d::eigen::DMatXX& propValues,
     Quad& quad) const {
   // property loop
-  const eigen::IRowN& pointNr = quad.getPointNr();
+  const axisem3d::eigen::IRowN& pointNr = quad.getPointNr();
   int nprop = (int)propKeys.size();
   for (int iprop = 0; iprop < nprop; iprop++) {
     // flattened to structured
-    eigen::arN_IColX inScope;
-    eigen::arN_DColX propValue;
+    axisem3d::eigen::arN_IColX inScope;
+    axisem3d::eigen::arN_DColX propValue;
     int row = 0;
     for (int ipnt = 0; ipnt < spectral::nPEM; ipnt++) {
       int nr = pointNr(ipnt);
@@ -131,20 +131,20 @@ Volumetric3D::setPropertiesToQuad(const std::vector<std::string>& propKeys,
 
 // Bond transformation for rotating Cijkl
 void
-Volumetric3D::bondTransformation(const eigen::DMat66& inCijkl,
+Volumetric3D::bondTransformation(const axisem3d::eigen::DMat66& inCijkl,
     double alpha,
     double beta,
     double gamma,
-    eigen::DMat66& outCijkl) {
+    axisem3d::eigen::DMat66& outCijkl) {
   // R
-  static eigen::DMat33 R1, R2, R3, R;
+  static axisem3d::eigen::DMat33 R1, R2, R3, R;
   R1 << 1., 0., 0., 0., cos(alpha), sin(alpha), 0., -sin(alpha), cos(alpha);
   R2 << cos(beta), 0., sin(beta), 0., 1., 0., -sin(beta), 0, cos(beta);
   R3 << cos(gamma), sin(gamma), 0., -sin(gamma), cos(gamma), 0., 0., 0., 1.;
   R = R1 * R2 * R3;
 
   // K
-  static eigen::DMat33 K1, K2, K3, K4;
+  static axisem3d::eigen::DMat33 K1, K2, K3, K4;
   K1.array() = R.array().pow(2.);
   K2 << R(0, 1) * R(0, 2), R(0, 2) * R(0, 0), R(0, 0) * R(0, 1), R(1, 1) * R(1, 2),
       R(1, 2) * R(1, 0), R(1, 0) * R(1, 1), R(2, 1) * R(2, 2), R(2, 2) * R(2, 0), R(2, 0) * R(2, 1);
@@ -155,7 +155,7 @@ Volumetric3D::bondTransformation(const eigen::DMat66& inCijkl,
       R(2, 2) * R(0, 0) + R(2, 0) * R(0, 2), R(2, 0) * R(0, 1) + R(2, 1) * R(0, 0),
       R(0, 1) * R(1, 2) + R(0, 2) * R(1, 1), R(0, 2) * R(1, 0) + R(0, 0) * R(1, 2),
       R(0, 0) * R(1, 1) + R(0, 1) * R(1, 0);
-  static eigen::DMat66 K;
+  static axisem3d::eigen::DMat66 K;
   K.block(0, 0, 3, 3) = K1;
   K.block(0, 3, 3, 3) = 2. * K2;
   K.block(3, 0, 3, 3) = K3;

--- a/src/models3D/volumetric/Volumetric3D.hpp
+++ b/src/models3D/volumetric/Volumetric3D.hpp
@@ -16,12 +16,12 @@
 #include "Model3D.hpp"
 #include <map>
 
-namespace eigen {
+namespace axisem3d::eigen {
   // anisotropy
   typedef Eigen::Matrix<int, 6, 6> IMat66;
   typedef Eigen::Matrix<double, 6, 6> DMat66;
   typedef Eigen::Matrix<double, 3, 3> DMat33;
-} // namespace eigen
+} // namespace axisem3d::eigen
 
 class Volumetric3D : public Model3D {
   public:
@@ -57,27 +57,27 @@ class Volumetric3D : public Model3D {
 
   // get properties
   virtual bool
-  getProperties(const eigen::DMatX3& spz,
-      const eigen::DMat24& nodalSZ,
-      eigen::IMatXX& inScopes,
-      eigen::DMatXX& propValues) const = 0;
+  getProperties(const axisem3d::eigen::DMatX3& spz,
+      const axisem3d::eigen::DMat24& nodalSZ,
+      axisem3d::eigen::IMatXX& inScopes,
+      axisem3d::eigen::DMatXX& propValues) const = 0;
 
   // set properties to quad
   virtual void
   setPropertiesToQuad(const std::vector<std::string>& propKeys,
       const std::vector<ReferenceKind>& refKinds,
-      const eigen::IMatXX& inScopes,
-      const eigen::DMatXX& propValues,
+      const axisem3d::eigen::IMatXX& inScopes,
+      const axisem3d::eigen::DMatXX& propValues,
       Quad& quad) const;
 
   ////////////////////////////// static //////////////////////////////
   // Bond transformation for rotating Cijkl
   static void
-  bondTransformation(const eigen::DMat66& inCijkl,
+  bondTransformation(const axisem3d::eigen::DMat66& inCijkl,
       double alpha,
       double beta,
       double gamma,
-      eigen::DMat66& outCijkl);
+      axisem3d::eigen::DMat66& outCijkl);
 
   public:
   // build from inparam

--- a/src/preloop/exodus/ABC.cpp
+++ b/src/preloop/exodus/ABC.cpp
@@ -180,12 +180,14 @@ ABC::verbose() const {
 }
 
 // get U0 solid
-eigen::DColX
-ABC::getU0Solid(
-    double span, const eigen::DColX& vp, const eigen::DColX& vs, const eigen::DColX& rho) const {
+axisem3d::eigen::DColX
+ABC::getU0Solid(double span,
+    const axisem3d::eigen::DColX& vp,
+    const axisem3d::eigen::DColX& vs,
+    const axisem3d::eigen::DColX& rho) const {
   // initialize
   int nr = (int)vp.rows();
-  eigen::DColX U0 = eigen::DColX::Zero(nr, 1);
+  axisem3d::eigen::DColX U0 = axisem3d::eigen::DColX::Zero(nr, 1);
   // compute by expr
   sSPAN = span;
   for (int alpha = 0; alpha < nr; alpha++) {
@@ -198,11 +200,12 @@ ABC::getU0Solid(
 }
 
 // get U0 fluid
-eigen::DColX
-ABC::getU0Fluid(double span, const eigen::DColX& vp, const eigen::DColX& rho) const {
+axisem3d::eigen::DColX
+ABC::getU0Fluid(
+    double span, const axisem3d::eigen::DColX& vp, const axisem3d::eigen::DColX& rho) const {
   // initialize
   int nr = (int)vp.rows();
-  eigen::DColX U0 = eigen::DColX::Zero(nr, 1);
+  axisem3d::eigen::DColX U0 = axisem3d::eigen::DColX::Zero(nr, 1);
   // compute by expr
   sSPAN = span;
   for (int alpha = 0; alpha < nr; alpha++) {

--- a/src/preloop/exodus/ABC.hpp
+++ b/src/preloop/exodus/ABC.hpp
@@ -61,13 +61,16 @@ class ABC {
   }
 
   // get U0 solid
-  eigen::DColX
-  getU0Solid(
-      double span, const eigen::DColX& vp, const eigen::DColX& vs, const eigen::DColX& rho) const;
+  axisem3d::eigen::DColX
+  getU0Solid(double span,
+      const axisem3d::eigen::DColX& vp,
+      const axisem3d::eigen::DColX& vs,
+      const axisem3d::eigen::DColX& rho) const;
 
   // get U0 fluid
-  eigen::DColX
-  getU0Fluid(double span, const eigen::DColX& vp, const eigen::DColX& rho) const;
+  axisem3d::eigen::DColX
+  getU0Fluid(
+      double span, const axisem3d::eigen::DColX& vp, const axisem3d::eigen::DColX& rho) const;
 
   private:
   /////// general data ///////

--- a/src/preloop/exodus/ExodusMesh.cpp
+++ b/src/preloop/exodus/ExodusMesh.cpp
@@ -119,14 +119,14 @@ ExodusMesh::verbose() const {
   ss << boxSubTitle(0, "Mesh geometry");
   ss << boxEquals(2, 20, "# elements", getNumQuads());
   ss << boxEquals(2, 20, "# nodes", getNumNodes());
-  const eigen::DMatX2_RM& nodalCoords = mySuperOnly().mNodalCoords;
+  const axisem3d::eigen::DMatX2_RM& nodalCoords = mySuperOnly().mNodalCoords;
   if (isCartesian()) {
     const std::string& rangeS = range(nodalCoords.col(0).minCoeff(), nodalCoords.col(0).maxCoeff());
     const std::string& rangeZ = range(nodalCoords.col(1).minCoeff(), nodalCoords.col(1).maxCoeff());
     ss << boxEquals(2, 20, "range of s-axis", rangeS);
     ss << boxEquals(2, 20, "range of z-axis", rangeZ);
   } else {
-    const eigen::DMatX2_RM& rt = geodesy::sz2rtheta(nodalCoords, true);
+    const axisem3d::eigen::DMatX2_RM& rt = geodesy::sz2rtheta(nodalCoords, true);
     const std::string& rangeR = range(rt.col(0).minCoeff(), rt.col(0).maxCoeff());
     const std::string& rangeT = range(rt.col(1).minCoeff(), rt.col(1).maxCoeff());
     ss << boxEquals(2, 20, "range of r-axis", rangeR);
@@ -140,7 +140,7 @@ ExodusMesh::verbose() const {
 
   // element geometry
   ss << boxSubTitle(0, "Element geometry");
-  const eigen::IColX& geometryType = mySuperOnly().mGeometryType;
+  const axisem3d::eigen::IColX& geometryType = mySuperOnly().mGeometryType;
   std::map<std::string, int> geomTypeMap = {
       {"spherical", geometryType.cwiseEqual(0).cast<int>().sum()},
       {"linear", geometryType.cwiseEqual(1).cast<int>().sum()},
@@ -149,7 +149,7 @@ ExodusMesh::verbose() const {
 
   // solid-fluid
   ss << boxSubTitle(0, "Element medium");
-  const eigen::IColX& isElementFluid = mySuperOnly().mIsElementFluid;
+  const axisem3d::eigen::IColX& isElementFluid = mySuperOnly().mIsElementFluid;
   std::map<std::string, int> solidFluidMap = {
       {"solid", getNumQuads() - isElementFluid.sum()}, {"fluid", isElementFluid.sum()}};
   ss << boxEquals(2, 20, solidFluidMap, ":");
@@ -190,7 +190,7 @@ void
 ExodusMesh::readBcastGlobal(const NetCDF_Reader& reader, double& memSup, double& memAll) {
   // read
   std::vector<std::string> glbVarNames, glbRecords;
-  eigen::DRowX glbVarValues;
+  axisem3d::eigen::DRowX glbVarValues;
   if (mpi::root()) {
     reader.readString("name_glo_var", glbVarNames);
     reader.readString("info_records", glbRecords);
@@ -261,7 +261,7 @@ ExodusMesh::readBcastCoordinates(const NetCDF_Reader& reader, double& memSup, do
     // read
     if (mpi::root()) {
       // read
-      eigen::DColX x, y;
+      axisem3d::eigen::DColX x, y;
       reader.readMatrix("coordx", x);
       reader.readMatrix("coordy", y);
       // cast to matrix
@@ -292,7 +292,7 @@ ExodusMesh::readBcastSideSets(const NetCDF_Reader& reader, double& memSup, doubl
   // values
   for (int iss = 0; iss < ssNames.size(); iss++) {
     // read
-    eigen::IColX elems, sides;
+    axisem3d::eigen::IColX elems, sides;
     if (mpi::root()) {
       const std::string& istr = bstring::toString(iss + 1);
       // elem
@@ -361,7 +361,7 @@ ExodusMesh::readBcastElemental(const NetCDF_Reader& reader, double& memSup, doub
             << (int)(std::find(evNames.begin(), evNames.end(), "element_type") - evNames.begin() +
                    1)
             << "eb1";
-      eigen::DRowX dbuffer;
+      axisem3d::eigen::DRowX dbuffer;
       reader.readMatrix(exKey.str(), dbuffer);
       mySuperOnly().mGeometryType = dbuffer.array().round().cast<int>();
 
@@ -428,7 +428,7 @@ ExodusMesh::readBcastRadial(const NetCDF_Reader& reader, double& memSup, double&
   double distTol = mGlobalVariables.at("dist_tolerance");
 
   // values
-  eigen::DMatXX rvValues;
+  axisem3d::eigen::DMatXX rvValues;
   if (mpi::root()) {
     //////////////////////// depth profile ////////////////////////
     // coords of axial points
@@ -459,12 +459,12 @@ ExodusMesh::readBcastRadial(const NetCDF_Reader& reader, double& memSup, double&
     }
 
     //////////////////////// depth values ////////////////////////
-    rvValues = eigen::DMatXX::Zero(coords.size(), rvNames.size());
+    rvValues = axisem3d::eigen::DMatXX::Zero(coords.size(), rvNames.size());
     for (int iname = 0; iname < rvNames.size(); iname++) {
       const std::string& rvName = rvNames[iname];
       if (mElementNodesStorage) {
         // storage = element_nodes
-        std::array<eigen::DRowX, 4> buf;
+        std::array<axisem3d::eigen::DRowX, 4> buf;
         reader.readMatrix(evNameMap.at(rvName + "_0"), buf[0]);
         reader.readMatrix(evNameMap.at(rvName + "_1"), buf[1]);
         reader.readMatrix(evNameMap.at(rvName + "_2"), buf[2]);
@@ -474,7 +474,7 @@ ExodusMesh::readBcastRadial(const NetCDF_Reader& reader, double& memSup, double&
         }
       } else {
         // storage = elements
-        eigen::DColX buf;
+        axisem3d::eigen::DColX buf;
         reader.readMatrix(evNameMap.at(rvName), buf);
         for (int idep = 0; idep < coords.size(); idep++) {
           rvValues(idep, iname) = buf(quad_nodes[idep].first);
@@ -484,7 +484,7 @@ ExodusMesh::readBcastRadial(const NetCDF_Reader& reader, double& memSup, double&
 
     //////////////////////// discontinuities ////////////////////////
     // read
-    eigen::DColX allDiscs;
+    axisem3d::eigen::DColX allDiscs;
     reader.readMatrix("discontinuities", allDiscs);
 
     // remove those out of model range
@@ -495,7 +495,7 @@ ExodusMesh::readBcastRadial(const NetCDF_Reader& reader, double& memSup, double&
         myDiscs.push_back(allDiscs(idisc));
       }
     }
-    mDiscontinuities = Eigen::Map<eigen::DColX>(myDiscs.data(), myDiscs.size());
+    mDiscontinuities = Eigen::Map<axisem3d::eigen::DColX>(myDiscs.data(), myDiscs.size());
 
     // verify discontinuities
     int disc_found = 0;
@@ -538,10 +538,10 @@ ExodusMesh::readBcastRadial(const NetCDF_Reader& reader, double& memSup, double&
   // memory infor
   timer::gPreloopTimer.message(
       eigen_tools::memoryInfo(mDiscontinuities, "discontinuities", memAll));
-  timer::gPreloopTimer.message(
-      eigen_tools::memoryInfo(Eigen::Map<eigen::DColX>(mRadialCoords.data(), mRadialCoords.size()),
-          "anchoring radii",
-          memAll));
+  timer::gPreloopTimer.message(eigen_tools::memoryInfo(
+      Eigen::Map<axisem3d::eigen::DColX>(mRadialCoords.data(), mRadialCoords.size()),
+      "anchoring radii",
+      memAll));
 
   // cast to map
   for (int irv = 0; irv < rvNames.size(); irv++) {
@@ -560,7 +560,7 @@ ExodusMesh::readBcastRadial(const NetCDF_Reader& reader, double& memSup, double&
     mpi::enterSuper();
     if (mpi::super()) {
       // cannot use const reference here
-      eigen::IMatX4_RM connect = mySuperOnly().mConnectivity.row(iquad);
+      axisem3d::eigen::IMatX4_RM connect = mySuperOnly().mConnectivity.row(iquad);
       for (int ivt = 0; ivt < 4; ivt++) {
         mySuperOnly().mConnectivity(iquad, ivt) = connect(Mapping::cycle4(ivt + axialSide - 3));
       }
@@ -584,7 +584,7 @@ ExodusMesh::readEllipticity(const NetCDF_Reader& reader, double& memSup, double&
       reader.readMatrix("ellipticity", mEllipticityCurve);
     } else {
       // constant 1 between [0, 1]
-      mEllipticityCurve = eigen::DMatXX_RM::Ones(2, 2);
+      mEllipticityCurve = axisem3d::eigen::DMatXX_RM::Ones(2, 2);
       mEllipticityCurve(0, 0) = 0.;
     }
     // to absolute
@@ -604,13 +604,13 @@ ExodusMesh::formNrAtNodes(const NrField& nrField, bool boundByInplane, bool useL
   if (mpi::rank() == mpi::nproc() - 1) {
     nNodeOnMe += getNumNodes() % mpi::nproc();
   }
-  const eigen::IColX& idR = eigen::IColX::LinSpaced(
+  const axisem3d::eigen::IColX& idR = axisem3d::eigen::IColX::LinSpaced(
       nNodeOnMe, mpi::rank() * nNodePP, mpi::rank() * nNodePP + nNodeOnMe - 1);
 
   // compute Nr on ranks
   timer::gPreloopTimer.begin("Computing Nr on ranks");
-  const eigen::DMatX2_RM& crdMe = mySuperOnly().mNodalCoords(idR, Eigen::all);
-  eigen::IColX nrMe = nrField.getNrAtPoints(crdMe);
+  const axisem3d::eigen::DMatX2_RM& crdMe = mySuperOnly().mNodalCoords(idR, Eigen::all);
+  axisem3d::eigen::IColX nrMe = nrField.getNrAtPoints(crdMe);
   // check Nr >= 1
   Eigen::Index loc = -1;
   int minNr = nrMe.minCoeff(&loc);
@@ -644,13 +644,13 @@ ExodusMesh::formNrAtNodes(const NrField& nrField, bool boundByInplane, bool useL
       double aveGLLSpacing = 0.;
       int inodeG = inode + mpi::rank() * nNodePP;
       for (int iquad : refQuads[inodeG]) {
-        const eigen::DRow2& sz0 =
+        const axisem3d::eigen::DRow2& sz0 =
             mySuperOnly().mNodalCoords.row(mySuperOnly().mConnectivity(iquad, 0));
-        const eigen::DRow2& sz1 =
+        const axisem3d::eigen::DRow2& sz1 =
             mySuperOnly().mNodalCoords.row(mySuperOnly().mConnectivity(iquad, 1));
-        const eigen::DRow2& sz2 =
+        const axisem3d::eigen::DRow2& sz2 =
             mySuperOnly().mNodalCoords.row(mySuperOnly().mConnectivity(iquad, 2));
-        const eigen::DRow2& sz3 =
+        const axisem3d::eigen::DRow2& sz3 =
             mySuperOnly().mNodalCoords.row(mySuperOnly().mConnectivity(iquad, 3));
         aveGLLSpacing += (sz0 - sz1).norm();
         aveGLLSpacing += (sz1 - sz2).norm();
@@ -688,7 +688,7 @@ ExodusMesh::formNrAtNodes(const NrField& nrField, bool boundByInplane, bool useL
   // assemble Nr on ranks
   timer::gPreloopTimer.begin("Assembling Nr on ranks");
   // allocate
-  mySuperOnly().mNodalNr = eigen::IColX::Zero(getNumNodes());
+  mySuperOnly().mNodalNr = axisem3d::eigen::IColX::Zero(getNumNodes());
   // copy to whole
   mySuperOnly().mNodalNr(idR, Eigen::all) = nrMe;
   // assemble by summation
@@ -704,7 +704,7 @@ std::string
 ExodusMesh::verboseNr(bool boundByInplane, bool useLuckyNumbers) const {
   std::stringstream ss;
   if (mpi::root()) {
-    const eigen::IColX& nodalNr = mySuperOnly().mNodalNr;
+    const axisem3d::eigen::IColX& nodalNr = mySuperOnly().mNodalNr;
     ss << bstring::boxTitle("Computed Nr on Mesh");
     ss << bstring::boxEquals(0, 6, "min Nr", nodalNr.minCoeff());
     ss << bstring::boxEquals(0, 6, "max Nr", nodalNr.maxCoeff());
@@ -784,7 +784,7 @@ ExodusMesh::boundaryInfoABC(const std::string& boundaryKey, double& outer, doubl
       if (geodesy::isCartesian()) {
         outer = mySuperOnly().mNodalCoords.col(0).maxCoeff();
       } else {
-        const eigen::DMatX2_RM& rt = geodesy::sz2rtheta(mySuperOnly().mNodalCoords, true);
+        const axisem3d::eigen::DMatX2_RM& rt = geodesy::sz2rtheta(mySuperOnly().mNodalCoords, true);
         outer = rt.col(1).maxCoeff();
       }
     }

--- a/src/preloop/exodus/ExodusMesh.hpp
+++ b/src/preloop/exodus/ExodusMesh.hpp
@@ -90,29 +90,29 @@ class ExodusMesh {
   // NOTE: these are elemental variables depending ONLY on radius (depth)
   //       all material properties in Exodus are assumed to be radial
   std::vector<double> mRadialCoords;
-  std::map<std::string, eigen::DColX> mRadialVariables;
+  std::map<std::string, axisem3d::eigen::DColX> mRadialVariables;
 
   // discontinuities
-  eigen::DColX mDiscontinuities = eigen::DColX(0);
+  axisem3d::eigen::DColX mDiscontinuities = axisem3d::eigen::DColX(0);
 
   // ellipticity (root-only)
-  eigen::DMatXX_RM mEllipticityCurve = eigen::DMatXX_RM(0, 0);
+  axisem3d::eigen::DMatXX_RM mEllipticityCurve = axisem3d::eigen::DMatXX_RM(0, 0);
 
   // super-only
   // wrap over super-only variables for thread safety
   struct ExodusSuperOnly {
     // connectivity
-    eigen::IMatX4_RM mConnectivity = eigen::IMatX4_RM(0, 4);
+    axisem3d::eigen::IMatX4_RM mConnectivity = axisem3d::eigen::IMatX4_RM(0, 4);
 
     // coords
-    eigen::DMatX2_RM mNodalCoords = eigen::DMatX2_RM(0, 2);
+    axisem3d::eigen::DMatX2_RM mNodalCoords = axisem3d::eigen::DMatX2_RM(0, 2);
 
     // element-wise variables
-    eigen::IColX mGeometryType = eigen::IColX(0);
-    eigen::IColX mIsElementFluid = eigen::IColX(0);
+    axisem3d::eigen::IColX mGeometryType = axisem3d::eigen::IColX(0);
+    axisem3d::eigen::IColX mIsElementFluid = axisem3d::eigen::IColX(0);
 
     // Nr at nodes
-    eigen::IColX mNodalNr = eigen::IColX(0);
+    axisem3d::eigen::IColX mNodalNr = axisem3d::eigen::IColX(0);
   } mSuperOnly__AccessOnlyBy__mySuperOnly;
 
   // set access to super-only
@@ -142,31 +142,31 @@ class ExodusMesh {
   }
 
   // coords
-  const eigen::DMatX2_RM&
+  const axisem3d::eigen::DMatX2_RM&
   getNodalCoords() const {
     return mySuperOnly().mNodalCoords;
   }
 
   // connectivity
-  const eigen::IMatX4_RM&
+  const axisem3d::eigen::IMatX4_RM&
   getConnectivity() const {
     return mySuperOnly().mConnectivity;
   }
 
   // geometry
-  const eigen::IColX&
+  const axisem3d::eigen::IColX&
   getGeometryType() const {
     return mySuperOnly().mGeometryType;
   }
 
   // fluid
-  const eigen::IColX&
+  const axisem3d::eigen::IColX&
   getIsElementFluid() const {
     return mySuperOnly().mIsElementFluid;
   }
 
   // Nr at nodes
-  const eigen::IColX&
+  const axisem3d::eigen::IColX&
   getNrAtNodes() const {
     return mySuperOnly().mNodalNr;
   }
@@ -197,13 +197,13 @@ class ExodusMesh {
   }
 
   // discontinuities
-  const eigen::DColX&
+  const axisem3d::eigen::DColX&
   getDiscontinuities() const {
     return mDiscontinuities;
   }
 
   // ellipticity
-  const eigen::DMatXX_RM&
+  const axisem3d::eigen::DMatXX_RM&
   getEllipticityCurve() const {
     return mEllipticityCurve;
   }
@@ -215,7 +215,7 @@ class ExodusMesh {
   }
 
   // radial variables
-  const std::map<std::string, eigen::DColX>&
+  const std::map<std::string, axisem3d::eigen::DColX>&
   getRadialVariables() const {
     return mRadialVariables;
   }

--- a/src/preloop/exodus/geodesy.cpp
+++ b/src/preloop/exodus/geodesy.cpp
@@ -35,9 +35,9 @@ namespace geodesy {
 
     // geographic
     // (lat, lon, r) on positive z-axis
-    eigen::DRow3 iLatLonRadiusAxisZ = eigen::DRow3::Zero();
+    axisem3d::eigen::DRow3 iLatLonRadiusAxisZ = axisem3d::eigen::DRow3::Zero();
     // Q matrix from source-centered to geographic
-    eigen::DMat33 iSrc2GeoQ = eigen::DMat33::Zero();
+    axisem3d::eigen::DMat33 iSrc2GeoQ = axisem3d::eigen::DMat33::Zero();
   } // namespace internal
 
   // setup
@@ -67,7 +67,7 @@ namespace geodesy {
 
     // ellipticity curve (only on root in ExodusMesh)
     if (mpi::root()) {
-      const eigen::DMatXX_RM& ellip = exMesh.getEllipticityCurve();
+      const axisem3d::eigen::DMatXX_RM& ellip = exMesh.getEllipticityCurve();
       internal::iEllipR.resize(ellip.cols());
       internal::iEllipF.resize(ellip.cols());
       for (int col = 0; col < ellip.cols(); col++) {
@@ -122,7 +122,7 @@ namespace geodesy {
     }
 
     // Q matrix from source-centered to geographic
-    eigen::DRow3 srctpr = llr2tpr(internal::iLatLonRadiusAxisZ, true);
+    axisem3d::eigen::DRow3 srctpr = llr2tpr(internal::iLatLonRadiusAxisZ, true);
     double theta = srctpr(0);
     double phi = srctpr(1);
     internal::iSrc2GeoQ(0, 0) = cos(theta) * cos(phi);
@@ -139,7 +139,7 @@ namespace geodesy {
 
   // verbose
   std::string
-  verbose(const eigen::DColX& discontinuities) {
+  verbose(const axisem3d::eigen::DColX& discontinuities) {
     std::stringstream ss;
     ss << bstring::boxTitle("Geodesy");
     // Cartesain
@@ -165,7 +165,7 @@ namespace geodesy {
         ///////// f at discontinuities /////////
         ss << bstring::boxSubTitle(0, "flattening at discontinuities");
         // compute f
-        const eigen::DColX& fDisc = computeFlattening(discontinuities);
+        const axisem3d::eigen::DColX& fDisc = computeFlattening(discontinuities);
         // width
         int width = (int)bstring::toString(internal::iOuterFlattening * numerical::dPi / 3.).size();
         // verbose f from surface to center

--- a/src/preloop/exodus/geodesy.hpp
+++ b/src/preloop/exodus/geodesy.hpp
@@ -20,10 +20,10 @@
 
 class ExodusMesh;
 
-namespace eigen {
+namespace axisem3d::eigen {
   typedef Eigen::Matrix<double, 1, 3> DRow3;
   typedef Eigen::Matrix<double, 3, 3> DMat33;
-} // namespace eigen
+} // namespace axisem3d::eigen
 
 namespace geodesy {
   // internal data
@@ -43,9 +43,9 @@ namespace geodesy {
 
     // geographic
     // (lat, lon, r) on positive z-axis
-    extern eigen::DRow3 iLatLonRadiusAxisZ;
+    extern axisem3d::eigen::DRow3 iLatLonRadiusAxisZ;
     // Q matrix from source-centered to geographic
-    extern eigen::DMat33 iSrc2GeoQ;
+    extern axisem3d::eigen::DMat33 iSrc2GeoQ;
   } // namespace internal
 
   // get
@@ -108,7 +108,7 @@ namespace geodesy {
 
   // verbose
   std::string
-  verbose(const eigen::DColX& discontinuities);
+  verbose(const axisem3d::eigen::DColX& discontinuities);
 
   /////////////////////////////// coords ///////////////////////////////
   // (s, z) -> (r, theta)
@@ -304,7 +304,7 @@ namespace geodesy {
   Col
   backAzimuth(const Mat& llr, bool ellipticity) {
     // event
-    const eigen::DRow3& srctpr = llr2tpr(internal::iLatLonRadiusAxisZ, ellipticity);
+    const axisem3d::eigen::DRow3& srctpr = llr2tpr(internal::iLatLonRadiusAxisZ, ellipticity);
     double d = sin(srctpr(1));
     double e = -cos(srctpr(1));
     double f = -sin(srctpr(0));

--- a/src/preloop/mesh/LocalMesh.cpp
+++ b/src/preloop/mesh/LocalMesh.cpp
@@ -27,9 +27,9 @@
 
 /////////////////////////// build //////////////////////////
 // constructor
-LocalMesh::LocalMesh(const ExodusMesh& exodusMesh, const eigen::DColX& weights) {
+LocalMesh::LocalMesh(const ExodusMesh& exodusMesh, const axisem3d::eigen::DColX& weights) {
   // domain decomposition
-  eigen::IColX elemRank;
+  axisem3d::eigen::IColX elemRank;
   mpi::enterSuper();
   if (mpi::super()) {
     timer::gPreloopTimer.begin("Mesh partitioning by Metis");
@@ -55,8 +55,9 @@ LocalMesh::LocalMesh(const ExodusMesh& exodusMesh, const eigen::DColX& weights) 
 
 // domain decomposition
 void
-LocalMesh::decomposeExodusMesh(
-    const ExodusMesh& exodusMesh, const eigen::DColX& weights, eigen::IColX& elemRank) {
+LocalMesh::decomposeExodusMesh(const ExodusMesh& exodusMesh,
+    const axisem3d::eigen::DColX& weights,
+    axisem3d::eigen::IColX& elemRank) {
   // metis
   double obj = axisem3d::metis::decompose(exodusMesh.getConnectivity(),
       exodusMesh.getIsElementFluid(),
@@ -74,7 +75,8 @@ LocalMesh::decomposeExodusMesh(
 
 // build local skeleton
 void
-LocalMesh::buildLocalSkeleton(const ExodusMesh& exodusMesh, const eigen::IColX& elemRank) {
+LocalMesh::buildLocalSkeleton(
+    const ExodusMesh& exodusMesh, const axisem3d::eigen::IColX& elemRank) {
   // gather world rank
   timer::gPreloopTimer.begin("Gathering world rank in mpi-groups");
   std::vector<int> vecWorldRank;
@@ -83,12 +85,12 @@ LocalMesh::buildLocalSkeleton(const ExodusMesh& exodusMesh, const eigen::IColX& 
 
   // compute local skeleton on root (leader of inferior group)
   timer::gPreloopTimer.begin("Building local skeleton on mpi-group leaders");
-  std::vector<eigen::IColX> vmL2GE;
-  std::vector<eigen::IMatX4_RM> vmConn;
-  std::vector<eigen::DMatX2_RM> vmCrds;
-  std::vector<eigen::IColX> vmGeom;
-  std::vector<eigen::IColX> vmIsFl;
-  std::vector<eigen::IColX> vmNdNr;
+  std::vector<axisem3d::eigen::IColX> vmL2GE;
+  std::vector<axisem3d::eigen::IMatX4_RM> vmConn;
+  std::vector<axisem3d::eigen::DMatX2_RM> vmCrds;
+  std::vector<axisem3d::eigen::IColX> vmGeom;
+  std::vector<axisem3d::eigen::IColX> vmIsFl;
+  std::vector<axisem3d::eigen::IColX> vmNdNr;
   if (mpi::root()) {
     // reserve
     vmL2GE.reserve(mpi::nproc());
@@ -116,14 +118,14 @@ LocalMesh::buildLocalSkeleton(const ExodusMesh& exodusMesh, const eigen::IColX& 
       }
 
       // global element tag
-      vmL2GE.push_back(Eigen::Map<eigen::IColX>(vL2GE.data(), vL2GE.size()));
+      vmL2GE.push_back(Eigen::Map<axisem3d::eigen::IColX>(vL2GE.data(), vL2GE.size()));
 
       // elemental fields simply sliced by vL2GE
       vmGeom.push_back(exodusMesh.getGeometryType()(vL2GE));
       vmIsFl.push_back(exodusMesh.getIsElementFluid()(vL2GE));
 
       // nodes: local to global
-      const eigen::IMatX4_RM& matConnG = exodusMesh.getConnectivity()(vL2GE, Eigen::all);
+      const axisem3d::eigen::IMatX4_RM& matConnG = exodusMesh.getConnectivity()(vL2GE, Eigen::all);
       std::vector<int> nL2G(matConnG.data(), matConnG.data() + matConnG.size());
       vector_tools::sortUnique(nL2G);
 
@@ -138,7 +140,7 @@ LocalMesh::buildLocalSkeleton(const ExodusMesh& exodusMesh, const eigen::IColX& 
         nG2L.insert({nL2G[inl], inl});
       }
       // node tag from global to local
-      eigen::IMatX4_RM mConn(vL2GE.size(), 4);
+      axisem3d::eigen::IMatX4_RM mConn(vL2GE.size(), 4);
       for (int iel = 0; iel < vL2GE.size(); iel++) {
         for (int ivt = 0; ivt < 4; ivt++) {
           mConn(iel, ivt) = nG2L.at(matConnG(iel, ivt));
@@ -162,18 +164,19 @@ LocalMesh::buildLocalSkeleton(const ExodusMesh& exodusMesh, const eigen::IColX& 
 
 // build element-GLL vicinity
 void
-LocalMesh::buildElementGLL_CommMPI(const ExodusMesh& exodusMesh, const eigen::IColX& elemRank) {
+LocalMesh::buildElementGLL_CommMPI(
+    const ExodusMesh& exodusMesh, const axisem3d::eigen::IColX& elemRank) {
   // local GLL
   timer::gPreloopTimer.begin("Constructing local element-GLL vicinity");
-  std::vector<eigen::IColX> localNeighbours; // useless
+  std::vector<axisem3d::eigen::IColX> localNeighbours; // useless
   int nLocalGLL = vicinity::connectivityToElementGLL(mConnectivity, mElementGLL, localNeighbours);
   timer::gPreloopTimer.ended("Constructing local element-GLL vicinity");
 
   // gather
   timer::gPreloopTimer.begin("Gathering input data in mpi-groups");
   std::vector<int> vecNLocalGLL;
-  std::vector<eigen::IMatXN_RM> vecElementGLL;
-  std::vector<eigen::IColX> vecL2G_Element;
+  std::vector<axisem3d::eigen::IMatXN_RM> vecElementGLL;
+  std::vector<axisem3d::eigen::IColX> vecL2G_Element;
   std::vector<int> vecWorldRank;
   mpi::gather(nLocalGLL, vecNLocalGLL, 0);
   mpi::gatherEigen(mElementGLL, vecElementGLL, 0);
@@ -184,21 +187,21 @@ LocalMesh::buildElementGLL_CommMPI(const ExodusMesh& exodusMesh, const eigen::IC
   // root
   timer::gPreloopTimer.begin("Building L2G-GLL and mpi communication "
                              "on mpi-group leaders");
-  std::vector<eigen::IColX> vecL2G_GLL;
+  std::vector<axisem3d::eigen::IColX> vecL2G_GLL;
   std::vector<std::vector<int>> vecVecCommProcGLL;
   if (mpi::root()) {
     // global element-GLL vicinity
     timer::gPreloopTimer.begin("Constructing global element-GLL vicinity");
-    eigen::IMatXN_RM globalElementGLL;
-    std::vector<eigen::IColX> globalNeighbours;
+    axisem3d::eigen::IMatXN_RM globalElementGLL;
+    std::vector<axisem3d::eigen::IColX> globalNeighbours;
     vicinity::connectivityToElementGLL(
         exodusMesh.getConnectivity(), globalElementGLL, globalNeighbours);
     // message large variables (here is a memory peak)
     timer::gPreloopTimer.message(
         eigen_tools::memoryInfo(globalElementGLL, "global element-GLL vicinity (super-only)"));
     int gNeighbSize = (int)vector_tools::totalSize(globalNeighbours);
-    timer::gPreloopTimer.message(
-        eigen_tools::memoryInfo(eigen::IColX(gNeighbSize), "global neighbourhood (super-only)"));
+    timer::gPreloopTimer.message(eigen_tools::memoryInfo(
+        axisem3d::eigen::IColX(gNeighbSize), "global neighbourhood (super-only)"));
     timer::gPreloopTimer.ended("Constructing global element-GLL vicinity");
 
     // L2G GLL matching by (element, nPol^2)
@@ -207,7 +210,7 @@ LocalMesh::buildElementGLL_CommMPI(const ExodusMesh& exodusMesh, const eigen::IC
     vecL2G_GLL.reserve(mpi::nproc());
     // loop over inferior ranks
     for (int rank = 0; rank < mpi::nproc(); rank++) {
-      const eigen::IColX& myL2G_GLL = vicinity::buildL2G_GLL(
+      const axisem3d::eigen::IColX& myL2G_GLL = vicinity::buildL2G_GLL(
           vecNLocalGLL[rank], vecL2G_Element[rank], vecElementGLL[rank], globalElementGLL);
       vecL2G_GLL.push_back(myL2G_GLL);
     }
@@ -258,7 +261,7 @@ LocalMesh::buildElementGLL_CommMPI(const ExodusMesh& exodusMesh, const eigen::IC
 std::string
 LocalMesh::verbose(const std::string& meshTitle,
     const std::string& weightsKey,
-    const eigen::DColX& weights) const {
+    const axisem3d::eigen::DColX& weights) const {
   // element distribution
   std::vector<int> evec;
   mpi::gather((int)mL2G_Element.rows(), evec, 0);
@@ -286,7 +289,7 @@ LocalMesh::verbose(const std::string& meshTitle,
     ss << boxEquals(0, 24, "# processors", mpi::nproc());
 
     // weights
-    eigen::DColX wcol = Eigen::Map<eigen::DColX>(wvec.data(), wvec.size());
+    axisem3d::eigen::DColX wcol = Eigen::Map<axisem3d::eigen::DColX>(wvec.data(), wvec.size());
     wcol /= wcol.sum();
     double mean = wcol.mean();
     double sd = sqrt((wcol.array() - mean).square().sum() / wcol.rows());
@@ -297,8 +300,8 @@ LocalMesh::verbose(const std::string& meshTitle,
     ss << boxEquals(2, 24, "unbalance factor (σ/μ)", sd / mean);
 
     // element
-    const eigen::DColX& ecol =
-        Eigen::Map<const eigen::IColX>(evec.data(), evec.size()).cast<double>();
+    const axisem3d::eigen::DColX& ecol =
+        Eigen::Map<const axisem3d::eigen::IColX>(evec.data(), evec.size()).cast<double>();
     mean = ecol.mean();
     sd = sqrt((ecol.array() - mean).square().sum() / ecol.rows());
     ss << boxSubTitle(0, "Element distribution");
@@ -308,8 +311,8 @@ LocalMesh::verbose(const std::string& meshTitle,
     ss << boxEquals(2, 24, "unbalance factor (σ/μ)", sd / mean);
 
     // GLL
-    const eigen::DColX& gcol =
-        Eigen::Map<const eigen::IColX>(gvec.data(), gvec.size()).cast<double>();
+    const axisem3d::eigen::DColX& gcol =
+        Eigen::Map<const axisem3d::eigen::IColX>(gvec.data(), gvec.size()).cast<double>();
     mean = gcol.mean();
     sd = sqrt((gcol.array() - mean).square().sum() / gcol.rows());
     ss << boxSubTitle(0, "GLL-point distribution");
@@ -320,8 +323,10 @@ LocalMesh::verbose(const std::string& meshTitle,
 
     // communication
     ss << boxSubTitle(0, "mpi communication");
-    const eigen::IColX& crcol = Eigen::Map<const eigen::IColX>(crvec.data(), crvec.size());
-    const eigen::IColX& cgcol = Eigen::Map<const eigen::IColX>(cgvec.data(), cgvec.size());
+    const axisem3d::eigen::IColX& crcol =
+        Eigen::Map<const axisem3d::eigen::IColX>(crvec.data(), crvec.size());
+    const axisem3d::eigen::IColX& cgcol =
+        Eigen::Map<const axisem3d::eigen::IColX>(cgvec.data(), cgvec.size());
     ss << boxEquals(2, 22, "# rank-to-rank pairs", crcol.sum() / 2);
     ss << boxEquals(2, 22, "# GLL-to-GLL paris", cgcol.sum() / 2);
     ss << boxBaseline() << "\n\n";
@@ -331,15 +336,15 @@ LocalMesh::verbose(const std::string& meshTitle,
 
 // plot domain decomposition
 void
-LocalMesh::plotDD(const std::string& fname, const eigen::DColX& weights) const {
+LocalMesh::plotDD(const std::string& fname, const axisem3d::eigen::DColX& weights) const {
   // compute coords at element center
   int nelem = (int)weights.rows();
-  eigen::DMatX2_RM center = eigen::DMatX2_RM::Zero(nelem, 2);
+  axisem3d::eigen::DMatX2_RM center = axisem3d::eigen::DMatX2_RM::Zero(nelem, 2);
   center(mL2G_Element, Eigen::all) = mpi::nodalToElemental(mConnectivity, mNodalCoords, false);
   mpi::sumEigen(center);
 
   // gather rank info
-  eigen::IColX elemRank = eigen::IColX::Zero(nelem);
+  axisem3d::eigen::IColX elemRank = axisem3d::eigen::IColX::Zero(nelem);
   elemRank(mL2G_Element).array() = mpi::rank();
   mpi::sumEigen(elemRank);
 

--- a/src/preloop/mesh/LocalMesh.hpp
+++ b/src/preloop/mesh/LocalMesh.hpp
@@ -25,7 +25,7 @@ class LocalMesh {
   public:
   /////////////////////////// build //////////////////////////
   // constructor
-  LocalMesh(const ExodusMesh& exodusMesh, const eigen::DColX& weights);
+  LocalMesh(const ExodusMesh& exodusMesh, const axisem3d::eigen::DColX& weights);
 
   // free memory after building SE_Model
   void
@@ -48,16 +48,17 @@ class LocalMesh {
   private:
   // domain decomposition
   static void
-  decomposeExodusMesh(
-      const ExodusMesh& exodusMesh, const eigen::DColX& weights, eigen::IColX& elemRank);
+  decomposeExodusMesh(const ExodusMesh& exodusMesh,
+      const axisem3d::eigen::DColX& weights,
+      axisem3d::eigen::IColX& elemRank);
 
   // build local skeleton
   void
-  buildLocalSkeleton(const ExodusMesh& exodusMesh, const eigen::IColX& elemRank);
+  buildLocalSkeleton(const ExodusMesh& exodusMesh, const axisem3d::eigen::IColX& elemRank);
 
   // build element-GLL vicinity and MPI communication
   void
-  buildElementGLL_CommMPI(const ExodusMesh& exodusMesh, const eigen::IColX& elemRank);
+  buildElementGLL_CommMPI(const ExodusMesh& exodusMesh, const axisem3d::eigen::IColX& elemRank);
 
   /////////////////////////// info //////////////////////////
   public:
@@ -65,25 +66,25 @@ class LocalMesh {
   std::string
   verbose(const std::string& meshTitle,
       const std::string& weightsKey,
-      const eigen::DColX& weights) const;
+      const axisem3d::eigen::DColX& weights) const;
 
   // plot domain decomposition
   void
-  plotDD(const std::string& fname, const eigen::DColX& weights) const;
+  plotDD(const std::string& fname, const axisem3d::eigen::DColX& weights) const;
 
   /////////////////////////// data //////////////////////////
   private:
   // local skeleton (super-only in ExodusMesh)
-  eigen::IColX mL2G_Element;
-  eigen::IMatX4_RM mConnectivity;
-  eigen::DMatX2_RM mNodalCoords;
-  eigen::IColX mGeometryType;
-  eigen::IColX mIsElementFluid;
-  eigen::IColX mNodalNr;
+  axisem3d::eigen::IColX mL2G_Element;
+  axisem3d::eigen::IMatX4_RM mConnectivity;
+  axisem3d::eigen::DMatX2_RM mNodalCoords;
+  axisem3d::eigen::IColX mGeometryType;
+  axisem3d::eigen::IColX mIsElementFluid;
+  axisem3d::eigen::IColX mNodalNr;
 
   // element-GLL vicinity
-  eigen::IColX mL2G_GLL;
-  eigen::IMatXN_RM mElementGLL;
+  axisem3d::eigen::IColX mL2G_GLL;
+  axisem3d::eigen::IMatXN_RM mElementGLL;
 
   // mpi communication
   std::vector<int> mCommProc;

--- a/src/preloop/mesh/eigen_mesh.hpp
+++ b/src/preloop/mesh/eigen_mesh.hpp
@@ -15,7 +15,7 @@
 #include "eigen_generic.hpp"
 #include "spectral.hpp"
 
-namespace eigen {
+namespace axisem3d::eigen {
   using Eigen::Dynamic;
   using Eigen::RowMajor;
 
@@ -28,6 +28,6 @@ namespace eigen {
   ///////// GLL-level /////////
   // GLL tag on elements
   typedef Eigen::Matrix<int, Dynamic, spectral::nPEM, RowMajor> IMatXN_RM;
-} // namespace eigen
+} // namespace axisem3d::eigen
 
 #endif /* eigen_mesh_hpp */

--- a/src/preloop/mesh/topology/metis.cpp
+++ b/src/preloop/mesh/topology/metis.cpp
@@ -14,11 +14,11 @@
 #include "vector_tools.hpp"
 #include <metis.h>
 
-namespace eigen {
+namespace axisem3d::eigen {
   // idx_t
   typedef Eigen::Matrix<idx_t, Eigen::Dynamic, 4, Eigen::RowMajor> IIMatX4_RM;
   typedef Eigen::Matrix<idx_t, Eigen::Dynamic, 1> IIColX;
-} // namespace eigen
+} // namespace axisem3d::eigen
 
 namespace axisem3d::metis {
   /////////////////////// internal functions ///////////////////////
@@ -32,8 +32,10 @@ namespace axisem3d::metis {
 
   // form adjacency
   void
-  formAdjacency(
-      const eigen::IIMatX4_RM& connectivity, idx_t ncommon, idx_t*& xadj, idx_t*& adjncy) {
+  formAdjacency(const axisem3d::eigen::IIMatX4_RM& connectivity,
+      idx_t ncommon,
+      idx_t*& xadj,
+      idx_t*& adjncy) {
     // get unique node list
     idx_t nelem = (idx_t)connectivity.rows();
     std::vector<idx_t> nodes(connectivity.data(), connectivity.data() + nelem * 4);
@@ -46,8 +48,8 @@ namespace axisem3d::metis {
     }
 
     // convert connectivity to CSR format
-    eigen::IIColX eptr = eigen::IIColX::LinSpaced(nelem + 1, 0, nelem * 4);
-    eigen::IIColX eind = eigen::IIColX(nelem * 4);
+    axisem3d::eigen::IIColX eptr = axisem3d::eigen::IIColX::LinSpaced(nelem + 1, 0, nelem * 4);
+    axisem3d::eigen::IIColX eind = axisem3d::eigen::IIColX(nelem * 4);
     for (idx_t ie = 0; ie < nelem; ie++) {
       for (idx_t ivt = 0; ivt < 4; ivt++) {
         eind(ie * 4 + ivt) = nG2L.at(connectivity(ie, ivt));
@@ -63,7 +65,7 @@ namespace axisem3d::metis {
 
   // form solid_fluid weights
   std::vector<idx_t>
-  formSF_Weights(const eigen::IColX& solid_fluid, idx_t* xadj, idx_t* adjncy) {
+  formSF_Weights(const axisem3d::eigen::IColX& solid_fluid, idx_t* xadj, idx_t* adjncy) {
     // allocate same length as adjncy
     idx_t nelem = (idx_t)solid_fluid.rows();
     std::vector<idx_t> adjwgt;
@@ -98,8 +100,9 @@ namespace axisem3d::metis {
   /////////////////////// external functions ///////////////////////
   // form neighbourhood of connectivity
   void
-  formNeighbourhood(
-      const eigen::IMatX4_RM& connectivity, int ncommon, std::vector<eigen::IColX>& neighbours) {
+  formNeighbourhood(const axisem3d::eigen::IMatX4_RM& connectivity,
+      int ncommon,
+      std::vector<axisem3d::eigen::IColX>& neighbours) {
     // form graph
     idx_t *xadj, *adjncy;
     formAdjacency(connectivity.cast<idx_t>(), (idx_t)ncommon, xadj, adjncy);
@@ -109,7 +112,7 @@ namespace axisem3d::metis {
     neighbours.reserve(connectivity.rows());
     for (int ie = 0; ie < connectivity.rows(); ie++) {
       int nNeighb = (int)(xadj[ie + 1] - xadj[ie]);
-      eigen::IColX neighb(nNeighb);
+      axisem3d::eigen::IColX neighb(nNeighb);
       for (int in = 0; in < nNeighb; in++) {
         neighb(in) = (int)adjncy[xadj[ie] + in];
       }
@@ -122,15 +125,15 @@ namespace axisem3d::metis {
 
   // domain decomposition
   double
-  decompose(const eigen::IMatX4_RM& connectivity,
-      const eigen::IColX& solid_fluid,
-      const eigen::DColX& weights,
+  decompose(const axisem3d::eigen::IMatX4_RM& connectivity,
+      const axisem3d::eigen::IColX& solid_fluid,
+      const axisem3d::eigen::DColX& weights,
       int npart,
       int rseed,
-      eigen::IColX& elemRank) {
+      axisem3d::eigen::IColX& elemRank) {
     // this cause error in Metis
     if (npart == 1) {
-      elemRank = eigen::IColX::Zero(connectivity.rows());
+      elemRank = axisem3d::eigen::IColX::Zero(connectivity.rows());
       return 0.;
     }
 
@@ -148,7 +151,7 @@ namespace axisem3d::metis {
 
     // weights
     idx_t* vwgt = NULL;
-    eigen::IIColX iweights; // must be defined outside if
+    axisem3d::eigen::IIColX iweights; // must be defined outside if
     if (weights.rows() == nelem) {
       // first normalize then magnify to avoid over/underflow
       double imax = std::numeric_limits<idx_t>::max() * .9;
@@ -170,7 +173,7 @@ namespace axisem3d::metis {
 
     //////////// output ////////////
     idx_t objval = 0;
-    eigen::IIColX erank(nelem);
+    axisem3d::eigen::IIColX erank(nelem);
 
     //////////// run ////////////
     error(METIS_PartGraphKway(&nelem,

--- a/src/preloop/mesh/topology/metis.hpp
+++ b/src/preloop/mesh/topology/metis.hpp
@@ -18,17 +18,18 @@
 namespace axisem3d::metis {
   // form neighbourhood of connectivity
   void
-  formNeighbourhood(
-      const eigen::IMatX4_RM& connectivity, int ncommon, std::vector<eigen::IColX>& neighbours);
+  formNeighbourhood(const axisem3d::eigen::IMatX4_RM& connectivity,
+      int ncommon,
+      std::vector<axisem3d::eigen::IColX>& neighbours);
 
   // domain decomposition
   double
-  decompose(const eigen::IMatX4_RM& connectivity,
-      const eigen::IColX& solid_fluid,
-      const eigen::DColX& weights,
+  decompose(const axisem3d::eigen::IMatX4_RM& connectivity,
+      const axisem3d::eigen::IColX& solid_fluid,
+      const axisem3d::eigen::DColX& weights,
       int npart,
       int rseed,
-      eigen::IColX& elemRank);
+      axisem3d::eigen::IColX& elemRank);
 } // namespace axisem3d::metis
 
 #endif /* metis_hpp */

--- a/src/preloop/mesh/topology/vicinity.cpp
+++ b/src/preloop/mesh/topology/vicinity.cpp
@@ -19,7 +19,7 @@
 namespace vicinity {
   /////////////////////// internal functions ///////////////////////
   void
-  sharedDOF(const eigen::IMatX4_RM& connectivity,
+  sharedDOF(const axisem3d::eigen::IMatX4_RM& connectivity,
       int elemA,
       int elemB,
       int& nodeOrEdgeA,
@@ -66,9 +66,9 @@ namespace vicinity {
   /////////////////////// external functions ///////////////////////
   // connectivity to element-GLL vicinity
   int
-  connectivityToElementGLL(const eigen::IMatX4_RM& connectivity,
-      eigen::IMatXN_RM& elementGLL,
-      std::vector<eigen::IColX>& neighbours) {
+  connectivityToElementGLL(const axisem3d::eigen::IMatX4_RM& connectivity,
+      axisem3d::eigen::IMatXN_RM& elementGLL,
+      std::vector<axisem3d::eigen::IColX>& neighbours) {
     using namespace constants;
 
     // get neighbours from metis
@@ -76,7 +76,7 @@ namespace vicinity {
 
     // init element-GLL vicinity
     int nelem = (int)connectivity.rows();
-    elementGLL = eigen::IMatXN_RM::Constant(nelem, spectral::nPEM, -1);
+    elementGLL = axisem3d::eigen::IMatXN_RM::Constant(nelem, spectral::nPEM, -1);
 
     // GLL tag start from 0
     int nGLL = 0;
@@ -125,13 +125,13 @@ namespace vicinity {
   }
 
   // build local to global GLL
-  eigen::IColX
+  axisem3d::eigen::IColX
   buildL2G_GLL(int nLocalGLL,
-      const eigen::IColX& myL2G_Element,
-      const eigen::IMatXN_RM& myElementGLL,
-      const eigen::IMatXN_RM& globalElementGLL) {
+      const axisem3d::eigen::IColX& myL2G_Element,
+      const axisem3d::eigen::IMatXN_RM& myElementGLL,
+      const axisem3d::eigen::IMatXN_RM& globalElementGLL) {
     // allocate and fill with -1
-    eigen::IColX myL2G_GLL = eigen::IColX::Constant(nLocalGLL, -1);
+    axisem3d::eigen::IColX myL2G_GLL = axisem3d::eigen::IColX::Constant(nLocalGLL, -1);
 
     // match local and global GLL tags by (element, ipnt)
     for (int letag = 0; letag < myL2G_Element.size(); letag++) {
@@ -150,13 +150,13 @@ namespace vicinity {
   // std::vector as the output to use mpi::scatter
   // rank0 gll0_0 gll0_1 ... -1 rank1 gll1_0 gll1_1 ... -1 rank2 ...
   std::vector<int>
-  buildCommMPI(const eigen::IColX& myL2G_Element,
-      const std::vector<eigen::IColX>& globalNeighbours,
-      const eigen::IColX& elemRank,
+  buildCommMPI(const axisem3d::eigen::IColX& myL2G_Element,
+      const std::vector<axisem3d::eigen::IColX>& globalNeighbours,
+      const axisem3d::eigen::IColX& elemRank,
       int myRank,
-      const eigen::IMatX4_RM& globalConnectivity,
-      const eigen::IMatXN_RM& myElementGLL,
-      const eigen::IColX& myL2G_GLL) {
+      const axisem3d::eigen::IMatX4_RM& globalConnectivity,
+      const axisem3d::eigen::IMatXN_RM& myElementGLL,
+      const axisem3d::eigen::IColX& myL2G_GLL) {
     using namespace constants;
     // structured output: std::map<otherRank, std::map<globalGLL, localGLL>>
     // A: Why each element is a map with key = globalGLL,

--- a/src/preloop/mesh/topology/vicinity.hpp
+++ b/src/preloop/mesh/topology/vicinity.hpp
@@ -136,28 +136,28 @@ namespace vicinity {
 
   // connectivity to element-GLL vicinity
   int
-  connectivityToElementGLL(const eigen::IMatX4_RM& connectivity,
-      eigen::IMatXN_RM& elementGLL,
-      std::vector<eigen::IColX>& neighbours);
+  connectivityToElementGLL(const axisem3d::eigen::IMatX4_RM& connectivity,
+      axisem3d::eigen::IMatXN_RM& elementGLL,
+      std::vector<axisem3d::eigen::IColX>& neighbours);
 
   // build local to global GLL
-  eigen::IColX
+  axisem3d::eigen::IColX
   buildL2G_GLL(int nLocalGLL,
-      const eigen::IColX& myL2G_Element,
-      const eigen::IMatXN_RM& myElementGLL,
-      const eigen::IMatXN_RM& globalElementGLL);
+      const axisem3d::eigen::IColX& myL2G_Element,
+      const axisem3d::eigen::IMatXN_RM& myElementGLL,
+      const axisem3d::eigen::IMatXN_RM& globalElementGLL);
 
   // build mpi communication
   // std::vector as the output to use mpi::scatter
   // rank0 gll0_0 gll0_1 ... -1 rank1 gll1_0 gll1_1 ... -1 rank2 ...
   std::vector<int>
-  buildCommMPI(const eigen::IColX& myL2G_Element,
-      const std::vector<eigen::IColX>& globalNeighbours,
-      const eigen::IColX& elemRank,
+  buildCommMPI(const axisem3d::eigen::IColX& myL2G_Element,
+      const std::vector<axisem3d::eigen::IColX>& globalNeighbours,
+      const axisem3d::eigen::IColX& elemRank,
       int myRank,
-      const eigen::IMatX4_RM& globalConnectivity,
-      const eigen::IMatXN_RM& myElementGLL,
-      const eigen::IColX& myL2G_GLL);
+      const axisem3d::eigen::IMatX4_RM& globalConnectivity,
+      const axisem3d::eigen::IMatXN_RM& myElementGLL,
+      const axisem3d::eigen::IColX& myL2G_GLL);
 } // namespace vicinity
 
 #endif /* vicinity_hpp */

--- a/src/preloop/nr_field/NrField.hpp
+++ b/src/preloop/nr_field/NrField.hpp
@@ -18,10 +18,10 @@
 // need distance tolerance for NrFieldPointwise
 class ExodusMesh;
 
-namespace eigen {
+namespace axisem3d::eigen {
   // coords
   typedef Eigen::Matrix<double, Eigen::Dynamic, 2, Eigen::RowMajor> DMatX2_RM;
-} // namespace eigen
+} // namespace axisem3d::eigen
 
 class NrField {
   public:
@@ -29,8 +29,8 @@ class NrField {
   virtual ~NrField() = default;
 
   // get nr by (s, z)
-  virtual eigen::IColX
-  getNrAtPoints(const eigen::DMatX2_RM& sz) const = 0;
+  virtual axisem3d::eigen::IColX
+  getNrAtPoints(const axisem3d::eigen::DMatX2_RM& sz) const = 0;
 
   // verbose
   virtual std::string

--- a/src/preloop/nr_field/NrFieldAnalytical.cpp
+++ b/src/preloop/nr_field/NrFieldAnalytical.cpp
@@ -63,22 +63,23 @@ NrFieldAnalytical::NrFieldAnalytical() {
 }
 
 // get nr by (s, z)
-eigen::IColX
-NrFieldAnalytical::getNrAtPoints(const eigen::DMatX2_RM& sz) const {
+axisem3d::eigen::IColX
+NrFieldAnalytical::getNrAtPoints(const axisem3d::eigen::DMatX2_RM& sz) const {
   // input: coordinates (s, z, r, theta, depth) and mUserParameters
   [[maybe_unused]]
-  const eigen::DColX& s = sz.col(0);
-  const eigen::DColX& z = sz.col(1);
-  const eigen::DMatX2_RM& rtheta = geodesy::sz2rtheta(sz, true);
-  const eigen::DColX& r = rtheta.col(0);
+  const axisem3d::eigen::DColX& s = sz.col(0);
+  const axisem3d::eigen::DColX& z = sz.col(1);
+  const axisem3d::eigen::DMatX2_RM& rtheta = geodesy::sz2rtheta(sz, true);
+  const axisem3d::eigen::DColX& r = rtheta.col(0);
   [[maybe_unused]]
-  const eigen::DColX& theta = rtheta.col(1);
+  const axisem3d::eigen::DColX& theta = rtheta.col(1);
   [[maybe_unused]]
-  const eigen::DColX& depth = geodesy::isCartesian() ? geodesy::getOuterRadius() - z.array()
-                                                     : geodesy::getOuterRadius() - r.array();
+  const axisem3d::eigen::DColX& depth =
+      geodesy::isCartesian() ? geodesy::getOuterRadius() - z.array()
+                             : geodesy::getOuterRadius() - r.array();
 
   // output: azimuthal dimension Nr
-  eigen::IColX nr = eigen::IColX::Zero(sz.rows());
+  axisem3d::eigen::IColX nr = axisem3d::eigen::IColX::Zero(sz.rows());
 
   ///////////////////////////////////////////////////////////////////
   ///////////////////// Only edit the box below /////////////////////

--- a/src/preloop/nr_field/NrFieldAnalytical.hpp
+++ b/src/preloop/nr_field/NrFieldAnalytical.hpp
@@ -21,8 +21,8 @@ class NrFieldAnalytical : public NrField {
   NrFieldAnalytical();
 
   // get nr by (s, z)
-  eigen::IColX
-  getNrAtPoints(const eigen::DMatX2_RM& sz) const;
+  axisem3d::eigen::IColX
+  getNrAtPoints(const axisem3d::eigen::DMatX2_RM& sz) const;
 
   // verbose
   std::string

--- a/src/preloop/nr_field/NrFieldConstant.cpp
+++ b/src/preloop/nr_field/NrFieldConstant.cpp
@@ -13,9 +13,9 @@
 #include "bstring.hpp"
 
 // get nr by (s, z)
-eigen::IColX
-NrFieldConstant::getNrAtPoints(const eigen::DMatX2_RM& sz) const {
-  return eigen::IColX::Constant(sz.rows(), mNr);
+axisem3d::eigen::IColX
+NrFieldConstant::getNrAtPoints(const axisem3d::eigen::DMatX2_RM& sz) const {
+  return axisem3d::eigen::IColX::Constant(sz.rows(), mNr);
 }
 
 // verbose

--- a/src/preloop/nr_field/NrFieldConstant.hpp
+++ b/src/preloop/nr_field/NrFieldConstant.hpp
@@ -22,8 +22,8 @@ class NrFieldConstant : public NrField {
   }
 
   // get nr by (s, z)
-  eigen::IColX
-  getNrAtPoints(const eigen::DMatX2_RM& sz) const;
+  axisem3d::eigen::IColX
+  getNrAtPoints(const axisem3d::eigen::DMatX2_RM& sz) const;
 
   // verbose
   std::string

--- a/src/preloop/nr_field/NrFieldPointwise.cpp
+++ b/src/preloop/nr_field/NrFieldPointwise.cpp
@@ -23,7 +23,7 @@ NrFieldPointwise::NrFieldPointwise(const std::string& fname, double factor, doub
   NetCDF_Reader reader;
   reader.open(io::popInputDir(fname));
   try {
-    eigen::IColX nrStart;
+    axisem3d::eigen::IColX nrStart;
     reader.readMatrix("starting_Nr_for_scanning", nrStart);
     mSumNrStart = nrStart.sum();
   } catch (...) {
@@ -33,9 +33,9 @@ NrFieldPointwise::NrFieldPointwise(const std::string& fname, double factor, doub
 }
 
 // get nr by (s, z)
-eigen::IColX
-NrFieldPointwise::getNrAtPoints(const eigen::DMatX2_RM& sz) const {
-  eigen::IColX result(sz.rows());
+axisem3d::eigen::IColX
+NrFieldPointwise::getNrAtPoints(const axisem3d::eigen::DMatX2_RM& sz) const {
+  axisem3d::eigen::IColX result(sz.rows());
   for (int ip = 0; ip < sz.rows(); ip++) {
     // get from r-tree without distance limit
     double max = std::numeric_limits<double>::max();
@@ -51,7 +51,7 @@ std::string
 NrFieldPointwise::verbose() const {
   std::stringstream ss;
   // statistics for verbose
-  const eigen::IColX& controlNr = mRTree->getAllValues();
+  const axisem3d::eigen::IColX& controlNr = mRTree->getAllValues();
   long sumNr = controlNr.cast<long>().sum();
   int aveNr = (int)round(1. * sumNr / controlNr.size());
 

--- a/src/preloop/nr_field/NrFieldPointwise.hpp
+++ b/src/preloop/nr_field/NrFieldPointwise.hpp
@@ -21,8 +21,8 @@ class NrFieldPointwise : public NrField {
   NrFieldPointwise(const std::string& fname, double factor, double distTolExact);
 
   // get nr by (s, z)
-  eigen::IColX
-  getNrAtPoints(const eigen::DMatX2_RM& sz) const;
+  axisem3d::eigen::IColX
+  getNrAtPoints(const axisem3d::eigen::DMatX2_RM& sz) const;
 
   // verbose
   std::string

--- a/src/preloop/nr_field/NrFieldStructured.cpp
+++ b/src/preloop/nr_field/NrFieldStructured.cpp
@@ -29,9 +29,9 @@ NrFieldStructured::NrFieldStructured(const std::string& fname, int valOutOfRange
 }
 
 // get nr by (s, z)
-eigen::IColX
-NrFieldStructured::getNrAtPoints(const eigen::DMatX2_RM& sz) const {
-  eigen::IColX nr(sz.rows());
+axisem3d::eigen::IColX
+NrFieldStructured::getNrAtPoints(const axisem3d::eigen::DMatX2_RM& sz) const {
+  axisem3d::eigen::IColX nr(sz.rows());
   if (geodesy::isCartesian()) {
     // Cartesian
     for (int ip = 0; ip < sz.rows(); ip++) {

--- a/src/preloop/nr_field/NrFieldStructured.hpp
+++ b/src/preloop/nr_field/NrFieldStructured.hpp
@@ -21,8 +21,8 @@ class NrFieldStructured : public NrField {
   NrFieldStructured(const std::string& fname, int valOutOfRange);
 
   // get nr by (s, z)
-  eigen::IColX
-  getNrAtPoints(const eigen::DMatX2_RM& sz) const;
+  axisem3d::eigen::IColX
+  getNrAtPoints(const axisem3d::eigen::DMatX2_RM& sz) const;
 
   // verbose
   std::string

--- a/src/preloop/output/ElementOutput.cpp
+++ b/src/preloop/output/ElementOutput.cpp
@@ -306,8 +306,8 @@ ElementOutput::release(const SE_Model& sem,
     const std::vector<Quad>& quads = sem.getQuads();
     for (int iquad = 0; iquad < quads.size(); iquad++) {
       // check coordinate ranges
-      const eigen::DCol2& sz = quads[iquad].getNodalSZ().rowwise().mean();
-      const eigen::DCol2& RZ =
+      const axisem3d::eigen::DCol2& sz = quads[iquad].getNodalSZ().rowwise().mean();
+      const axisem3d::eigen::DCol2& RZ =
           geodesy::isCartesian() ? sz : geodesy::sz2rtheta(sz, false, 0, 1, 1, 0);
       if (elgrp->mMinR < RZ(0) && RZ(0) < elgrp->mMaxR && elgrp->mMinZ < RZ(1) &&
           RZ(1) < elgrp->mMaxZ && quads[iquad].fluid() == elgrp->mFluid) {
@@ -335,11 +335,11 @@ ElementOutput::release(const SE_Model& sem,
       for (int qTag : opQuads) {
         int edge = -1;
         // compute coordinates
-        const eigen::DMat24& sz = quads[qTag].getNodalSZ();
-        const eigen::DMat24& RZ =
+        const axisem3d::eigen::DMat24& sz = quads[qTag].getNodalSZ();
+        const axisem3d::eigen::DMat24& RZ =
             geodesy::isCartesian() ? sz : geodesy::sz2rtheta(sz, false, 0, 1, 1, 0);
         // coordinate to check
-        eigen::DRow4 x;
+        axisem3d::eigen::DRow4 x;
         double xmin = 0, xmax = 0;
         if (elgrp->mEdgeDim == 0 && !geodesy::isCartesian()) {
           // theta to arc length
@@ -380,11 +380,11 @@ ElementOutput::release(const SE_Model& sem,
     std::vector<double> phisToUse = elgrp->mPhis;
     // given lat, lon
     int nll = (int)elgrp->mLats.size();
-    eigen::DMatXX llr(nll, 3);
-    llr.col(0) = Eigen::Map<const eigen::DColX>(elgrp->mLats.data(), nll);
-    llr.col(1) = Eigen::Map<const eigen::DColX>(elgrp->mLons.data(), nll);
+    axisem3d::eigen::DMatXX llr(nll, 3);
+    llr.col(0) = Eigen::Map<const axisem3d::eigen::DColX>(elgrp->mLats.data(), nll);
+    llr.col(1) = Eigen::Map<const axisem3d::eigen::DColX>(elgrp->mLons.data(), nll);
     llr.col(2).fill(geodesy::getOuterRadius());
-    const eigen::DMatXX& spz = geodesy::llr2spz(llr, true);
+    const axisem3d::eigen::DMatXX& spz = geodesy::llr2spz(llr, true);
     for (int iphi = 0; iphi < nll; iphi++) {
       phisToUse.push_back(spz(iphi, 1));
     }

--- a/src/preloop/output/StationOutput.cpp
+++ b/src/preloop/output/StationOutput.cpp
@@ -248,11 +248,11 @@ StationOutput::release(const SE_Model& sem,
     //////////// read ////////////
     timer::gPreloopTimer.begin("Reading and broadcasting station file");
     std::vector<std::string> stKeys;
-    eigen::DMatX3 stCrds;
+    axisem3d::eigen::DMatX3 stCrds;
     // open and read
     if (mpi::root()) {
       // use map to check key uniqueness while recording order in map
-      std::map<std::string, std::pair<int, eigen::DRow3>> keyCrds;
+      std::map<std::string, std::pair<int, axisem3d::eigen::DRow3>> keyCrds;
       const std::vector<std::string>& lines =
           readLines(io::popInputDir(stgrp->mFileName), "StationOutput::release");
       int numStations = 0;
@@ -280,7 +280,7 @@ StationOutput::release(const SE_Model& sem,
               stgrp->mGroupName);
         }
         // coords
-        static eigen::DRow3 crd;
+        static axisem3d::eigen::DRow3 crd;
         crd(0) = cast<double>(words[2], "StationOutput::release");
         crd(1) = cast<double>(words[3], "StationOutput::release");
         crd(2) = cast<double>(words.back(), "StationOutput::release");
@@ -309,7 +309,7 @@ StationOutput::release(const SE_Model& sem,
     int numStations = (int)stKeys.size();
     for (int ist = 0; ist < numStations; ist++) {
       // compute spz
-      const eigen::DRow3& spz = Source::computeSPZ(sem,
+      const axisem3d::eigen::DRow3& spz = Source::computeSPZ(sem,
           stCrds.row(ist),
           stgrp->mSourceCentered,
           stgrp->mXY,
@@ -430,7 +430,7 @@ StationOutput::release(const SE_Model& sem,
       }
 
       // compute spz
-      const eigen::DRow3& spz = Source::computeSPZ(sem,
+      const axisem3d::eigen::DRow3& spz = Source::computeSPZ(sem,
           stCrds.row(ist),
           stgrp->mSourceCentered,
           stgrp->mXY,
@@ -443,12 +443,12 @@ StationOutput::release(const SE_Model& sem,
 
       // theta and baz
       double theta = geodesy::sz2rtheta(spz, true, 0, 2, 2, 0)(0);
-      const eigen::DRow3& llr = geodesy::spz2llr(spz, true, false);
+      const axisem3d::eigen::DRow3& llr = geodesy::spz2llr(spz, true, false);
       double baz = geodesy::backAzimuth(llr, true)(0);
 
       // inplane interpolation
       int quadTag = stationQuad.at(ist);
-      const eigen::DRowN& inplaneFactor =
+      const axisem3d::eigen::DRowN& inplaneFactor =
           sem.computeInplaneFactor(spz({0, 2}).transpose(), quadTag);
 
       // station

--- a/src/preloop/se_model/SE_Model.cpp
+++ b/src/preloop/se_model/SE_Model.cpp
@@ -97,15 +97,15 @@ SE_Model::SE_Model(const ExodusMesh& exodusMesh,
   timer::gPreloopTimer.begin("Assembling mass and normal");
   // init mpi buffer
   timer::gPreloopTimer.begin("Creating MPI buffers");
-  std::vector<eigen::DColX> bufSend, bufRecv;
+  std::vector<axisem3d::eigen::DColX> bufSend, bufRecv;
   int nCommProc = (int)localMesh.mCommProc.size();
   for (int iproc = 0; iproc < nCommProc; iproc++) {
     int commSize = 0;
     for (int igll : localMesh.mCommMyGLL[iproc]) {
       commSize += mGLLPoints[igll].getCommSize();
     }
-    bufSend.push_back(eigen::DColX::Zero(commSize));
-    bufRecv.push_back(eigen::DColX::Zero(commSize));
+    bufSend.push_back(axisem3d::eigen::DColX::Zero(commSize));
+    bufRecv.push_back(axisem3d::eigen::DColX::Zero(commSize));
   }
   timer::gPreloopTimer.ended("Creating MPI buffers");
 
@@ -158,12 +158,12 @@ SE_Model::SE_Model(const ExodusMesh& exodusMesh,
 
   // range
   timer::gPreloopTimer.begin("Computing local mesh range");
-  const eigen::DMatX2_RM& sz = localMesh.mNodalCoords;
+  const axisem3d::eigen::DMatX2_RM& sz = localMesh.mNodalCoords;
   mRangeS(0) = sz.col(0).minCoeff() - mDistToleranceMesh;
   mRangeS(1) = sz.col(0).maxCoeff() + mDistToleranceMesh;
   mRangeZ(0) = sz.col(1).minCoeff() - mDistToleranceMesh;
   mRangeZ(1) = sz.col(1).maxCoeff() + mDistToleranceMesh;
-  const eigen::DMatX2_RM& rt = geodesy::sz2rtheta(sz, true);
+  const axisem3d::eigen::DMatX2_RM& rt = geodesy::sz2rtheta(sz, true);
   mRangeR(0) = rt.col(0).minCoeff() - mDistToleranceMesh;
   mRangeR(1) = rt.col(0).maxCoeff() + mDistToleranceMesh;
   mRangeT(0) = rt.col(1).minCoeff();
@@ -173,7 +173,7 @@ SE_Model::SE_Model(const ExodusMesh& exodusMesh,
 
 // step 2: get dt for attenuation
 double
-SE_Model::computeDt(double courant, const ABC& abc, eigen::DCol2& sz) const {
+SE_Model::computeDt(double courant, const ABC& abc, axisem3d::eigen::DCol2& sz) const {
   // minimum dt over quads
   double dtMin = std::numeric_limits<double>::max();
   for (const Quad& quad : mQuads) {
@@ -186,13 +186,13 @@ SE_Model::computeDt(double courant, const ABC& abc, eigen::DCol2& sz) const {
 
   // minimum dt over ranks
   std::vector<double> dtV;
-  std::vector<eigen::DCol2> szV;
+  std::vector<axisem3d::eigen::DCol2> szV;
   mpi::gather(dtMin, dtV, MPI_ALL);
   mpi::gatherEigen(sz, szV, MPI_ALL);
 
   // rank with minimum dt
   Eigen::Index rankDt = -1;
-  dtMin = Eigen::Map<eigen::DColX>(dtV.data(), dtV.size()).minCoeff(&rankDt);
+  dtMin = Eigen::Map<axisem3d::eigen::DColX>(dtV.data(), dtV.size()).minCoeff(&rankDt);
   sz = szV[rankDt];
 
   // round to 4 significant figures to avoid dumping error
@@ -242,7 +242,7 @@ SE_Model::release(const ABC& abc,
 }
 
 // step 4: measure
-eigen::DColX
+axisem3d::eigen::DColX
 SE_Model::measureCost(const ExodusMesh& exodusMesh,
     const LocalMesh& localMesh,
     const TimeScheme& timeScheme,
@@ -394,7 +394,7 @@ SE_Model::measureCost(const ExodusMesh& exodusMesh,
 
   // read libraries locally
   timer::gPreloopTimer.begin("Computing weights from libraries");
-  eigen::DColX weightsLocal(mQuads.size());
+  axisem3d::eigen::DColX weightsLocal(mQuads.size());
   for (int iquad = 0; iquad < mQuads.size(); iquad++) {
     // element
     weightsLocal(iquad) = elemCostLibrary.at(elemSign(iquad));
@@ -412,15 +412,15 @@ SE_Model::measureCost(const ExodusMesh& exodusMesh,
   // gather weights
   timer::gPreloopTimer.begin("Gathering and broadcasting weights");
   // gather
-  std::vector<eigen::DColX> weightsLocalVec;
-  std::vector<eigen::IColX> L2G_ElementVec;
+  std::vector<axisem3d::eigen::DColX> weightsLocalVec;
+  std::vector<axisem3d::eigen::IColX> L2G_ElementVec;
   mpi::gatherEigen(weightsLocal, weightsLocalVec, 0);
   mpi::gatherEigen(localMesh.mL2G_Element, L2G_ElementVec, 0);
   // map global on root
-  eigen::DColX weightsGlobal;
+  axisem3d::eigen::DColX weightsGlobal;
   if (mpi::root()) {
     // allocate and fill with a crazy number
-    weightsGlobal = eigen::DColX::Constant(exodusMesh.getNumQuads(), numerical::dErr);
+    weightsGlobal = axisem3d::eigen::DColX::Constant(exodusMesh.getNumQuads(), numerical::dErr);
     for (int iproc = 0; iproc < mpi::nproc(); iproc++) {
       for (int ielem = 0; ielem < L2G_ElementVec[iproc].size(); ielem++) {
         int iglob = L2G_ElementVec[iproc][ielem];
@@ -446,7 +446,7 @@ SE_Model::verbose(const std::string& titleSEM) const {
   mpi::gather(nGLL, nGLLV, MPI_ALL);
   // find rank with max
   Eigen::Index rankMax;
-  Eigen::Map<eigen::IColX>(nQuadV.data(), nQuadV.size()).maxCoeff(&rankMax);
+  Eigen::Map<axisem3d::eigen::IColX>(nQuadV.data(), nQuadV.size()).maxCoeff(&rankMax);
 
   // verbose
   using namespace bstring;
@@ -463,9 +463,9 @@ SE_Model::verbose(const std::string& titleSEM) const {
 ////////////////// source-receiver //////////////////
 // get total undulation
 double
-SE_Model::getTotalUndulation(const eigen::DRow3& spzRef) const {
+SE_Model::getTotalUndulation(const axisem3d::eigen::DRow3& spzRef) const {
   double totalUndulation = 0.;
-  static eigen::DColX undulation(1);
+  static axisem3d::eigen::DColX undulation(1);
   for (const std::shared_ptr<const Geometric3D>& m : mModelsG3D) {
     m->getUndulation(spzRef, undulation);
     totalUndulation += undulation(0);
@@ -474,8 +474,8 @@ SE_Model::getTotalUndulation(const eigen::DRow3& spzRef) const {
 }
 
 // undulated to reference
-eigen::DRow3
-SE_Model::undulatedToReference(const eigen::DRow3& spzUnd) const {
+axisem3d::eigen::DRow3
+SE_Model::undulatedToReference(const axisem3d::eigen::DRow3& spzUnd) const {
   // no geometric model
   if (mModelsG3D.size() == 0) {
     return spzUnd;
@@ -483,13 +483,15 @@ SE_Model::undulatedToReference(const eigen::DRow3& spzUnd) const {
 
   // lambda to compute R from spz
   static auto toR =
-      geodesy::isCartesian() ? [](const eigen::DRow3& spz) -> double { return spz(2); }
-  : [](const eigen::DRow3& spz) -> double { return sqrt(spz(0) * spz(0) + spz(2) * spz(2)); };
+      geodesy::isCartesian() ? [](const axisem3d::eigen::DRow3& spz) -> double { return spz(2); }
+                             : [](const axisem3d::eigen::DRow3& spz) -> double {
+      return sqrt(spz(0) * spz(0) + spz(2) * spz(2));
+    };
 
   // lambda to compute spz from R
   static auto toSPZ = geodesy::isCartesian()
-      ? [](double R, eigen::DRow3& spz, double sint, double cost) { spz(2) = R; }
-      : [](double R, eigen::DRow3& spz, double sint, double cost) {
+      ? [](double R, axisem3d::eigen::DRow3& spz, double sint, double cost) { spz(2) = R; }
+      : [](double R, axisem3d::eigen::DRow3& spz, double sint, double cost) {
           spz(0) = R * sint;
           spz(2) = R * cost;
         };
@@ -507,7 +509,7 @@ SE_Model::undulatedToReference(const eigen::DRow3& spzUnd) const {
   double undR = toR(spzUnd);
 
   // intitial guess
-  eigen::DRow3 spzRef = spzUnd;
+  axisem3d::eigen::DRow3 spzRef = spzUnd;
   if (undR < geodesy::getInnerRadius()) {
     toSPZ(geodesy::getInnerRadius(), spzRef, sint, cost);
   }
@@ -545,7 +547,7 @@ SE_Model::formInplaneRTree() {
   mRTreeFluid = std::make_unique<RTreeND<2, 1, int>>();
   mRTreeSolid = std::make_unique<RTreeND<2, 1, int>>();
   for (int iquad = 0; iquad < mQuads.size(); iquad++) {
-    const eigen::DCol2& sz = mQuads[iquad].getNodalSZ().rowwise().mean();
+    const axisem3d::eigen::DCol2& sz = mQuads[iquad].getNodalSZ().rowwise().mean();
     if (mQuads[iquad].fluid()) {
       mRTreeFluid->addLeaf(sz, iquad);
     } else {
@@ -556,12 +558,12 @@ SE_Model::formInplaneRTree() {
 
 // locate inplane
 int
-SE_Model::locateInplane(const eigen::DCol2& sz, bool inFluid) const {
+SE_Model::locateInplane(const axisem3d::eigen::DCol2& sz, bool inFluid) const {
   // mesh range
   if ((sz(0) < mRangeS(0) || sz(0) > mRangeS(1)) || (sz(1) < mRangeZ(0) || sz(1) > mRangeZ(1))) {
     return -1;
   }
-  const eigen::DCol2& rt = geodesy::sz2rtheta(sz, false);
+  const axisem3d::eigen::DCol2& rt = geodesy::sz2rtheta(sz, false);
   if ((rt(0) < mRangeR(0) || rt(0) > mRangeR(1)) ||
       (rt(1) * rt(0) < mRangeT(0) * rt(0) - mDistToleranceMesh ||
           rt(1) * rt(0) > mRangeT(1) * rt(0) + mDistToleranceMesh)) {
@@ -587,7 +589,7 @@ SE_Model::locateInplane(const eigen::DCol2& sz, bool inFluid) const {
   }
 
   // locate inplane
-  static eigen::DCol2 xieta;
+  static axisem3d::eigen::DCol2 xieta;
   for (int iq = 0; iq < vals.size(); iq++) {
     int iquad = vals[iq](0);
     if (mQuads[iquad].inverseMapping(sz, xieta)) {
@@ -599,15 +601,15 @@ SE_Model::locateInplane(const eigen::DCol2& sz, bool inFluid) const {
 }
 
 // compute inplane factor
-eigen::DRowN
-SE_Model::computeInplaneFactor(const eigen::DCol2& sz, int iquad) const {
-  static eigen::DCol2 xieta;
+axisem3d::eigen::DRowN
+SE_Model::computeInplaneFactor(const axisem3d::eigen::DCol2& sz, int iquad) const {
+  static axisem3d::eigen::DCol2 xieta;
   if (mQuads[iquad].inverseMapping(sz, xieta)) {
-    const eigen::DColP& weightsXi = interpLagrange(
+    const axisem3d::eigen::DColP& weightsXi = interpLagrange(
         xieta(0), mQuads[iquad].axial() ? spectrals::gPositionsGLJ : spectrals::gPositionsGLL);
-    const eigen::DColP& weightsEta = interpLagrange(xieta(1), spectrals::gPositionsGLL);
-    return Eigen::Map<const eigen::DRowN>(
-        eigen::DMatPP_RM(weightsXi * weightsEta.transpose()).data());
+    const axisem3d::eigen::DColP& weightsEta = interpLagrange(xieta(1), spectrals::gPositionsGLL);
+    return Eigen::Map<const axisem3d::eigen::DRowN>(
+        axisem3d::eigen::DMatPP_RM(weightsXi * weightsEta.transpose()).data());
   } else {
     throw std::runtime_error("SE_Model::computeInterpFactor || "
                              "Location is not in the given quad.");

--- a/src/preloop/se_model/SE_Model.hpp
+++ b/src/preloop/se_model/SE_Model.hpp
@@ -47,7 +47,7 @@ class SE_Model {
 
   // step 2: get dt for attenuation
   double
-  computeDt(double courant, const ABC& abc, eigen::DCol2& sz) const;
+  computeDt(double courant, const ABC& abc, axisem3d::eigen::DCol2& sz) const;
 
   // step 3: release to domain
   void
@@ -58,7 +58,7 @@ class SE_Model {
       Domain& domain);
 
   // step 4: measure
-  eigen::DColX
+  axisem3d::eigen::DColX
   measureCost(const ExodusMesh& exodusMesh,
       const LocalMesh& localMesh,
       const TimeScheme& timeScheme,
@@ -71,11 +71,11 @@ class SE_Model {
   ////////////////// source-receiver //////////////////
   // get total undulation
   double
-  getTotalUndulation(const eigen::DRow3& spzRef) const;
+  getTotalUndulation(const axisem3d::eigen::DRow3& spzRef) const;
 
   // undulated to reference
-  eigen::DRow3
-  undulatedToReference(const eigen::DRow3& spzUnd) const;
+  axisem3d::eigen::DRow3
+  undulatedToReference(const axisem3d::eigen::DRow3& spzUnd) const;
 
   // form inplane RTree
   void
@@ -83,11 +83,11 @@ class SE_Model {
 
   // locate inplane
   int
-  locateInplane(const eigen::DCol2& sz, bool inFluid) const;
+  locateInplane(const axisem3d::eigen::DCol2& sz, bool inFluid) const;
 
   // compute inplane factor
-  eigen::DRowN
-  computeInplaneFactor(const eigen::DCol2& sz, int iquad) const;
+  axisem3d::eigen::DRowN
+  computeInplaneFactor(const axisem3d::eigen::DCol2& sz, int iquad) const;
 
   // get quads
   const std::vector<Quad>&
@@ -132,10 +132,10 @@ class SE_Model {
   std::vector<std::shared_ptr<const Geometric3D>> mModelsG3D;
 
   // local mesh range
-  eigen::DCol2 mRangeS = eigen::DCol2::Zero();
-  eigen::DCol2 mRangeZ = eigen::DCol2::Zero();
-  eigen::DCol2 mRangeR = eigen::DCol2::Zero();
-  eigen::DCol2 mRangeT = eigen::DCol2::Zero();
+  axisem3d::eigen::DCol2 mRangeS = axisem3d::eigen::DCol2::Zero();
+  axisem3d::eigen::DCol2 mRangeZ = axisem3d::eigen::DCol2::Zero();
+  axisem3d::eigen::DCol2 mRangeR = axisem3d::eigen::DCol2::Zero();
+  axisem3d::eigen::DCol2 mRangeT = axisem3d::eigen::DCol2::Zero();
 
   // inplane
   std::unique_ptr<RTreeND<2, 1, int>> mRTreeFluid = nullptr;

--- a/src/preloop/se_model/eigen_sem.hpp
+++ b/src/preloop/se_model/eigen_sem.hpp
@@ -15,7 +15,7 @@
 #include "eigen_generic.hpp"
 #include "spectral.hpp"
 
-namespace eigen {
+namespace axisem3d::eigen {
   using Eigen::Dynamic;
   using Eigen::RowMajor;
   using spectral::nPEM;
@@ -45,17 +45,17 @@ namespace eigen {
   // 3D scalar field on an element with max Nr
   typedef Eigen::Matrix<double, Dynamic, nPEM> DMatXN;
   // 3D scalar field on an element with different Nr's
-  typedef std::array<eigen::DColX, nPEM> arN_DColX;
-  typedef std::array<eigen::IColX, nPEM> arN_IColX;
+  typedef std::array<axisem3d::eigen::DColX, nPEM> arN_DColX;
+  typedef std::array<axisem3d::eigen::IColX, nPEM> arN_IColX;
   // 3D scalar field on an edge with different Nr's
-  typedef std::array<eigen::DColX, nPED> arP_DColX;
+  typedef std::array<axisem3d::eigen::DColX, nPED> arP_DColX;
   // 3D vector field on an edge with different Nr's
-  typedef std::array<eigen::DMatX3, nPED> arP_DMatX3;
+  typedef std::array<axisem3d::eigen::DMatX3, nPED> arP_DMatX3;
 
   ///////// GLL structured /////////
   typedef Eigen::Matrix<double, nPED, 1> DColP;
   typedef Eigen::Matrix<double, nPED, nPED, Eigen::RowMajor> DMatPP_RM;
-} // namespace eigen
+} // namespace axisem3d::eigen
 
 /////////////////////////// 1D/3D operations ///////////////////////////
 namespace op1D_3D {
@@ -178,9 +178,9 @@ namespace op1D_3D {
   }
 
   // 1D structured
-  inline eigen::DMatPP_RM
-  toPP(const eigen::DMatXN& mat) {
-    return Eigen::Map<const eigen::DMatPP_RM>(mat.data());
+  inline axisem3d::eigen::DMatPP_RM
+  toPP(const axisem3d::eigen::DMatXN& mat) {
+    return Eigen::Map<const axisem3d::eigen::DMatPP_RM>(mat.data());
   }
 } // namespace op1D_3D
 

--- a/src/preloop/se_model/gll/GLLPoint.cpp
+++ b/src/preloop/se_model/gll/GLLPoint.cpp
@@ -65,19 +65,19 @@ GLLPoint::release(const ABC& abc, const TimeScheme& timeScheme, Domain& domain) 
     } else {
       if (mMassSolid.rows() == 1 && mSumRhoDepth.rows() == 1 && mNormalTop.rows() == 1) {
         // 1D mass with ocean load
-        eigen::DCol2 nsz;
+        axisem3d::eigen::DCol2 nsz;
         nsz << mNormalTop(0, 0), mNormalTop(0, 2);
-        const eigen::DCol2& nrt = geodesy::sz2rtheta(nsz, false);
+        const axisem3d::eigen::DCol2& nrt = geodesy::sz2rtheta(nsz, false);
         mass = std::make_unique<const MassOceanLoad1D>(
             mMassSolid(0), mSumRhoDepth(0) * nrt(0), nrt(1));
       } else {
         // 3D mass with ocean load
         // mass of ocean
-        eigen::DColX massOcean;
-        const eigen::DColX& area = mNormalTop.rowwise().norm();
+        axisem3d::eigen::DColX massOcean;
+        const axisem3d::eigen::DColX& area = mNormalTop.rowwise().norm();
         op1D_3D::times(mSumRhoDepth, area, massOcean);
         // unit normal
-        const eigen::DMatX3& unitNormal = mNormalTop.array().colwise() / area.array();
+        const axisem3d::eigen::DMatX3& unitNormal = mNormalTop.array().colwise() / area.array();
         // mass
         mass = std::make_unique<const MassOceanLoad3D>(op1D_3D::to3D(mMassSolid, mNr),
             op1D_3D::to3D(massOcean, mNr),
@@ -149,9 +149,9 @@ GLLPoint::release(const ABC& abc, const TimeScheme& timeScheme, Domain& domain) 
   for (auto itm = mClaytonABC.begin(); itm != mClaytonABC.end(); itm++) {
     for (auto itv = itm->second.begin(); itv != itm->second.end(); itv++) {
       bool fluid = std::get<0>(*itv);
-      const eigen::DMatX3& nABC = std::get<1>(*itv);
-      const eigen::DColX& rhoVp = std::get<2>(*itv);
-      const eigen::DColX& rhoVs = std::get<3>(*itv);
+      const axisem3d::eigen::DMatX3& nABC = std::get<1>(*itv);
+      const axisem3d::eigen::DColX& rhoVp = std::get<2>(*itv);
+      const axisem3d::eigen::DColX& rhoVs = std::get<3>(*itv);
       // fluid
       if (fluid) {
         std::unique_ptr<const ClaytonFluid> clayton = nullptr;
@@ -169,15 +169,15 @@ GLLPoint::release(const ABC& abc, const TimeScheme& timeScheme, Domain& domain) 
         std::unique_ptr<const ClaytonSolid> clayton = nullptr;
         if (nABC.rows() == 1 && rhoVp.rows() == 1 && rhoVs.rows() == 1) {
           // 1D solid
-          eigen::DCol2 nsz;
+          axisem3d::eigen::DCol2 nsz;
           nsz << nABC(0, 0), nABC(0, 2);
-          const eigen::DCol2& nrt = geodesy::sz2rtheta(nsz, false);
+          const axisem3d::eigen::DCol2& nrt = geodesy::sz2rtheta(nsz, false);
           clayton = std::make_unique<const ClaytonSolid1D>(
               mSolidPoint, rhoVp(0), rhoVs(0), nrt(0), nrt(1));
         } else {
           // 3D solid
-          const eigen::DColX& area = nABC.rowwise().norm();
-          const eigen::DMatX3& unitNormal = nABC.array().colwise() / area.array();
+          const axisem3d::eigen::DColX& area = nABC.rowwise().norm();
+          const axisem3d::eigen::DMatX3& unitNormal = nABC.array().colwise() / area.array();
           clayton = std::make_unique<const ClaytonSolid3D>(mSolidPoint,
               op1D_3D::to3D(rhoVp, mNr),
               op1D_3D::to3D(rhoVs, mNr),

--- a/src/preloop/se_model/gll/GLLPoint.hpp
+++ b/src/preloop/se_model/gll/GLLPoint.hpp
@@ -29,7 +29,7 @@ class GLLPoint {
   public:
   // setup by Quad
   void
-  setup(int globalTag, int nr, const eigen::DCol2& coords, double distTol) {
+  setup(int globalTag, int nr, const axisem3d::eigen::DCol2& coords, double distTol) {
     if (mGlobalTag == -1) {
       // set by the first element
       mGlobalTag = globalTag;
@@ -48,14 +48,14 @@ class GLLPoint {
 
   // add mass
   void
-  addMass(const eigen::DColX& mass, bool fluid) {
-    eigen::DColX& myMass = fluid ? mMassFluid : mMassSolid;
+  addMass(const axisem3d::eigen::DColX& mass, bool fluid) {
+    axisem3d::eigen::DColX& myMass = fluid ? mMassFluid : mMassSolid;
     op1D_3D::addTo(mass, myMass);
   }
 
   // add solid-fluid
   void
-  addNormalSF(const eigen::DMatX3& nSF) {
+  addNormalSF(const axisem3d::eigen::DMatX3& nSF) {
     op1D_3D::addTo(nSF, mNormalSFU);
     mNormalSFA = mNormalSFU;
   }
@@ -67,16 +67,19 @@ class GLLPoint {
   void
   addClaytonABC(const std::string& key,
       bool fluid,
-      const eigen::DMatX3& nABC,
-      const eigen::DColX& rho,
-      const eigen::DColX& vp,
-      const eigen::DColX& vs) {
-    eigen::DColX rhoVp, rhoVs;
+      const axisem3d::eigen::DMatX3& nABC,
+      const axisem3d::eigen::DColX& rho,
+      const axisem3d::eigen::DColX& vp,
+      const axisem3d::eigen::DColX& vs) {
+    axisem3d::eigen::DColX rhoVp, rhoVs;
     op1D_3D::times(rho, vp, rhoVp);
     op1D_3D::times(rho, vs, rhoVs);
     // init (key, vector<tuple>)
-    mClaytonABC.insert(
-        {key, std::vector<std::tuple<bool, eigen::DMatX3, eigen::DColX, eigen::DColX>>()});
+    mClaytonABC.insert({key,
+        std::vector<std::tuple<bool,
+            axisem3d::eigen::DMatX3,
+            axisem3d::eigen::DColX,
+            axisem3d::eigen::DColX>>()});
     mClaytonABC.at(key).push_back({fluid, nABC, rhoVp, rhoVs});
     // try reduce to 1D
     op1D_3D::tryReduceTo1D(std::get<1>(mClaytonABC.at(key).back()));
@@ -86,14 +89,14 @@ class GLLPoint {
 
   // add gamma
   void
-  addGamma(const eigen::DColX& Gamma) {
+  addGamma(const axisem3d::eigen::DColX& Gamma) {
     op1D_3D::addTo(Gamma, mGamma);
     mCountGammasAdded++;
   }
 
   // add ocean load
   void
-  addOceanLoad(const eigen::DMatX3& nTop, const eigen::DColX& sumRhoDepth) {
+  addOceanLoad(const axisem3d::eigen::DMatX3& nTop, const axisem3d::eigen::DColX& sumRhoDepth) {
     op1D_3D::addTo(nTop, mNormalTop);
     // this is done repeatedly at shared points
     mSumRhoDepth = sumRhoDepth;
@@ -121,7 +124,7 @@ class GLLPoint {
 
   // feed comm
   void
-  feedComm(eigen::DColX& buffer, int& row) const {
+  feedComm(axisem3d::eigen::DColX& buffer, int& row) const {
     // reference element count
     buffer(row, 0) = mElementCount;
     // size info
@@ -140,11 +143,11 @@ class GLLPoint {
     row += mMassSolid.size();
     // solid-fluid
     buffer.block(row, 0, mNormalSFA.size(), 1) =
-        Eigen::Map<const eigen::DColX>(mNormalSFA.data(), mNormalSFA.size(), 1);
+        Eigen::Map<const axisem3d::eigen::DColX>(mNormalSFA.data(), mNormalSFA.size(), 1);
     row += mNormalSFA.size();
     // ocean load
     buffer.block(row, 0, mNormalTop.size(), 1) =
-        Eigen::Map<const eigen::DColX>(mNormalTop.data(), mNormalTop.size(), 1);
+        Eigen::Map<const axisem3d::eigen::DColX>(mNormalTop.data(), mNormalTop.size(), 1);
     row += mNormalTop.size();
     // sponge boundary
     buffer.block(row, 0, mGamma.size(), 1) = mGamma;
@@ -153,7 +156,7 @@ class GLLPoint {
 
   // extract comm
   void
-  extractComm(const eigen::DColX& buffer, int& row) {
+  extractComm(const axisem3d::eigen::DColX& buffer, int& row) {
     // reference element count
     mElementCount += (int)round(buffer(row, 0));
     // size info
@@ -170,12 +173,12 @@ class GLLPoint {
     op1D_3D::addTo(buffer.block(row, 0, sizeMassSolid, 1), mMassSolid);
     row += sizeMassSolid;
     // solid-fluid
-    op1D_3D::addTo(Eigen::Map<const eigen::DMatX3>(
+    op1D_3D::addTo(Eigen::Map<const axisem3d::eigen::DMatX3>(
                        buffer.block(row, 0, sizeNormalSFA, 1).data(), sizeNormalSFA / 3, 3),
         mNormalSFA);
     row += sizeNormalSFA;
     // ocean load
-    op1D_3D::addTo(Eigen::Map<const eigen::DMatX3>(
+    op1D_3D::addTo(Eigen::Map<const axisem3d::eigen::DMatX3>(
                        buffer.block(row, 0, sizeNormalTop, 1).data(), sizeNormalTop / 3, 3),
         mNormalTop);
     row += sizeNormalTop;
@@ -222,32 +225,34 @@ class GLLPoint {
   int mNr = -1;
 
   // coords
-  eigen::DCol2 mCoords = eigen::DCol2::Zero();
+  axisem3d::eigen::DCol2 mCoords = axisem3d::eigen::DCol2::Zero();
 
   // reference element count
   int mElementCount = 0;
 
   // mass
-  eigen::DColX mMassFluid = eigen::DColX::Zero(0);
-  eigen::DColX mMassSolid = eigen::DColX::Zero(0);
+  axisem3d::eigen::DColX mMassFluid = axisem3d::eigen::DColX::Zero(0);
+  axisem3d::eigen::DColX mMassSolid = axisem3d::eigen::DColX::Zero(0);
 
   // solid-fuild
   // unassembled
-  eigen::DMatX3 mNormalSFU = eigen::DMatX3::Zero(0, 3);
+  axisem3d::eigen::DMatX3 mNormalSFU = axisem3d::eigen::DMatX3::Zero(0, 3);
   // assembled
-  eigen::DMatX3 mNormalSFA = eigen::DMatX3::Zero(0, 3);
+  axisem3d::eigen::DMatX3 mNormalSFA = axisem3d::eigen::DMatX3::Zero(0, 3);
 
   // Clayton ABC {key, {fluid/solid, normal, rho * vp, rho * vs}}
-  std::map<std::string, std::vector<std::tuple<bool, eigen::DMatX3, eigen::DColX, eigen::DColX>>>
+  std::map<std::string,
+      std::vector<std::
+              tuple<bool, axisem3d::eigen::DMatX3, axisem3d::eigen::DColX, axisem3d::eigen::DColX>>>
       mClaytonABC;
 
   // Kosloff_Kosloff sponge boundary
-  eigen::DColX mGamma = eigen::DColX::Zero(0);
+  axisem3d::eigen::DColX mGamma = axisem3d::eigen::DColX::Zero(0);
   int mCountGammasAdded = 0;
 
   // ocean load
-  eigen::DMatX3 mNormalTop = eigen::DMatX3::Zero(0, 3);
-  eigen::DColX mSumRhoDepth = eigen::DColX::Zero(0);
+  axisem3d::eigen::DMatX3 mNormalTop = axisem3d::eigen::DMatX3::Zero(0, 3);
+  axisem3d::eigen::DColX mSumRhoDepth = axisem3d::eigen::DColX::Zero(0);
 
   // axial
   bool mAxial = false;

--- a/src/preloop/se_model/quad/Quad.cpp
+++ b/src/preloop/se_model/quad/Quad.cpp
@@ -48,12 +48,12 @@ Quad::Quad(
   mEdgesOnBoundary.insert({"SOLID_FLUID", exodusMesh.getSide("solid_fluid_boundary", mGlobalTag)});
 
   // Nr field
-  static eigen::DRow4 nodalNr;
+  static axisem3d::eigen::DRow4 nodalNr;
   for (int ivt = 0; ivt < 4; ivt++) {
     int inode = localMesh.mConnectivity(mLocalTag, ivt);
     nodalNr(ivt) = localMesh.mNodalNr(inode);
   }
-  mPointNr = std::make_unique<eigen::IRowN>(
+  mPointNr = std::make_unique<axisem3d::eigen::IRowN>(
       spectrals::interpolateGLL(nodalNr, axial()).array().round().cast<int>());
   // round to lucky numbers
   if (useLuckyNumbers) {
@@ -63,7 +63,7 @@ Quad::Quad(
   ////////////// components //////////////
   // 1) mapping
   // form nodal (s,z)
-  static eigen::DMat24 nodalSZ;
+  static axisem3d::eigen::DMat24 nodalSZ;
   for (int ivt = 0; ivt < 4; ivt++) {
     int inode = localMesh.mConnectivity(mLocalTag, ivt);
     nodalSZ.col(ivt) = localMesh.mNodalCoords.row(inode).transpose();
@@ -95,11 +95,11 @@ Quad::Quad(
 void
 Quad::setupGLL(const ABC& abc, const LocalMesh& localMesh, std::vector<GLLPoint>& GLLPoints) const {
   // compute mass
-  static eigen::DMat2N sz;
-  static std::array<eigen::DMat22, spectral::nPEM> J;
-  const eigen::DRowN& ifact = computeIntegralFactor(sz, J);
-  const eigen::arN_DColX& J_PRT = mUndulation->getMassJacobian(sz);
-  const eigen::arN_DColX& mass = mMaterial->getMass(ifact, J_PRT, mFluid);
+  static axisem3d::eigen::DMat2N sz;
+  static std::array<axisem3d::eigen::DMat22, spectral::nPEM> J;
+  const axisem3d::eigen::DRowN& ifact = computeIntegralFactor(sz, J);
+  const axisem3d::eigen::arN_DColX& J_PRT = mUndulation->getMassJacobian(sz);
+  const axisem3d::eigen::arN_DColX& mass = mMaterial->getMass(ifact, J_PRT, mFluid);
 
   // setup tags, nr, coords and mass
   for (int ipnt = 0; ipnt < spectral::nPEM; ipnt++) {
@@ -122,7 +122,7 @@ Quad::setupGLL(const ABC& abc, const LocalMesh& localMesh, std::vector<GLLPoint>
   if (mEdgesOnBoundary.at("SOLID_FLUID") != -1) {
     // compute normals
     static std::vector<int> ipnts;
-    static eigen::arP_DMatX3 nSF;
+    static axisem3d::eigen::arP_DMatX3 nSF;
     computeNormal(mEdgesOnBoundary.at("SOLID_FLUID"), sz, J, ipnts, nSF);
     // add normals to points
     for (int ip = 0; ip < spectral::nPED; ip++) {
@@ -145,10 +145,10 @@ Quad::setupGLL(const ABC& abc, const LocalMesh& localMesh, std::vector<GLLPoint>
       }
       // compute normals
       static std::vector<int> ipnts;
-      static eigen::arP_DMatX3 nABC;
+      static axisem3d::eigen::arP_DMatX3 nABC;
       computeNormal(mEdgesOnBoundary.at(key), sz, J, ipnts, nABC);
       // get properties from material
-      eigen::arN_DColX rho, vp, vs;
+      axisem3d::eigen::arN_DColX rho, vp, vs;
       mMaterial->getPointwiseRhoVpVs(rho, vp, vs);
       // add ABCs to points
       for (int ip = 0; ip < spectral::nPED; ip++) {
@@ -162,16 +162,16 @@ Quad::setupGLL(const ABC& abc, const LocalMesh& localMesh, std::vector<GLLPoint>
   // sponge ABC
   if (abc.sponge()) {
     // get material
-    eigen::arN_DColX rho, vp, vs;
+    axisem3d::eigen::arN_DColX rho, vp, vs;
     mMaterial->getPointwiseRhoVpVs(rho, vp, vs);
 
     // loop over gll
     for (int ipnt = 0; ipnt < spectral::nPEM; ipnt++) {
       // regularize 1D/3D
-      op1D_3D::regularize1D<eigen::DColX>(
+      op1D_3D::regularize1D<axisem3d::eigen::DColX>(
           {std::ref(rho[ipnt]), std::ref(vp[ipnt]), std::ref(vs[ipnt])});
       // compute maximum gamma among all boundaries
-      eigen::DColX gammaMax = eigen::DColX::Zero((*mPointNr)(ipnt), 1);
+      axisem3d::eigen::DColX gammaMax = axisem3d::eigen::DColX::Zero((*mPointNr)(ipnt), 1);
       double distToOuter_min = 1.;
       for (const std::string& key : abc.getBoundaryKeys()) {
         /////////// pattern ///////////
@@ -186,7 +186,7 @@ Quad::setupGLL(const ABC& abc, const LocalMesh& localMesh, std::vector<GLLPoint>
           coord = (key == "RIGHT" ? sz(0, ipnt) : sz(1, ipnt));
           r = sz(1, ipnt);
         } else {
-          const eigen::DCol2& rt = geodesy::sz2rtheta(sz.col(ipnt).eval(), false);
+          const axisem3d::eigen::DCol2& rt = geodesy::sz2rtheta(sz.col(ipnt).eval(), false);
           coord = (key == "RIGHT" ? rt(1) : rt(0));
           r = rt(0);
         }
@@ -228,10 +228,10 @@ Quad::setupGLL(const ABC& abc, const LocalMesh& localMesh, std::vector<GLLPoint>
   if (mEdgesOnBoundary.at("TOP") != -1 && (*mOceanLoad)) {
     // compute normals
     static std::vector<int> ipnts;
-    static eigen::arP_DMatX3 nTop;
+    static axisem3d::eigen::arP_DMatX3 nTop;
     computeNormal(mEdgesOnBoundary.at("TOP"), sz, J, ipnts, nTop);
     // add ocean loads to points
-    const eigen::arP_DColX& sumRhoDepth = mOceanLoad->getPointwise();
+    const axisem3d::eigen::arP_DColX& sumRhoDepth = mOceanLoad->getPointwise();
     for (int ip = 0; ip < spectral::nPED; ip++) {
       int igll = localMesh.mElementGLL(mLocalTag, ipnts[ip]);
       GLLPoints[igll].addOceanLoad(nTop[ip], sumRhoDepth[ip]);
@@ -261,27 +261,27 @@ Quad::setupGLL(const ABC& abc, const LocalMesh& localMesh, std::vector<GLLPoint>
 double
 Quad::computeDt(double courant, const ABC& abc) const {
   // get vp
-  const eigen::DColX& vmaxNr = mMaterial->getMaxVelocity().rowwise().maxCoeff();
+  const axisem3d::eigen::DColX& vmaxNr = mMaterial->getMaxVelocity().rowwise().maxCoeff();
 
   // 1D coords in reference configuration
-  const eigen::DMat2N& szRef = getPointSZ();
+  const axisem3d::eigen::DMat2N& szRef = getPointSZ();
 
   // compute coords on slices
-  std::vector<eigen::DMat2N> szNr;
-  const eigen::DMatXN& dZ = mUndulation->getElemental();
+  std::vector<axisem3d::eigen::DMat2N> szNr;
+  const axisem3d::eigen::DMatXN& dZ = mUndulation->getElemental();
   // both 1D and 3D undulation
   if (geodesy::isCartesian()) {
     for (int nr = 0; nr < dZ.rows(); nr++) {
-      eigen::DMat2N sz = szRef;
+      axisem3d::eigen::DMat2N sz = szRef;
       sz.row(1) += dZ.row(nr);
       szNr.push_back(sz);
     }
   } else {
-    const eigen::DMat2N& rt = geodesy::sz2rtheta(szRef, false);
-    const eigen::DRowN& sint = rt.row(1).array().sin();
-    const eigen::DRowN& cost = rt.row(1).array().cos();
+    const axisem3d::eigen::DMat2N& rt = geodesy::sz2rtheta(szRef, false);
+    const axisem3d::eigen::DRowN& sint = rt.row(1).array().sin();
+    const axisem3d::eigen::DRowN& cost = rt.row(1).array().cos();
     for (int nr = 0; nr < dZ.rows(); nr++) {
-      eigen::DMat2N sz = szRef;
+      axisem3d::eigen::DMat2N sz = szRef;
       sz.row(0) += dZ.row(nr).cwiseProduct(sint);
       sz.row(1) += dZ.row(nr).cwiseProduct(cost);
       szNr.push_back(sz);
@@ -296,7 +296,7 @@ Quad::computeDt(double courant, const ABC& abc) const {
     double vmax = (vmaxNr.rows() == 1) ? vmaxNr(0) : vmaxNr(nr);
 
     // hmin
-    const eigen::DMat2N& sz = (szNr.size() == 1) ? szNr[0] : szNr[nr];
+    const axisem3d::eigen::DMat2N& sz = (szNr.size() == 1) ? szNr[0] : szNr[nr];
     double hmin = std::numeric_limits<double>::max();
     for (int ipnt0 = 0; ipnt0 < spectral::nPEM - 1; ipnt0++) {
       int ipol0 = ipnt0 / spectral::nPED;
@@ -343,8 +343,8 @@ Quad::release(const LocalMesh& localMesh,
     const std::unique_ptr<const AttBuilder>& attBuilder,
     Domain& domain) {
   // gradient-quadrature operator
-  static eigen::DMat2N sz;
-  static eigen::DMatPP_RM ifPP;
+  static axisem3d::eigen::DMat2N sz;
+  static axisem3d::eigen::DMatPP_RM ifPP;
   std::unique_ptr<const GradientQuadrature<numerical::Real>> grad =
       createGradient<numerical::Real>(sz, ifPP);
   // particle relabelling transformation
@@ -386,14 +386,15 @@ Quad::release(const LocalMesh& localMesh,
 
 //////////////////////// interal ////////////////////////
 // compute integral factor
-eigen::DRowN
-Quad::computeIntegralFactor(eigen::DMat2N& sz, std::array<eigen::DMat22, spectral::nPEM>& J) const {
+axisem3d::eigen::DRowN
+Quad::computeIntegralFactor(
+    axisem3d::eigen::DMat2N& sz, std::array<axisem3d::eigen::DMat22, spectral::nPEM>& J) const {
   // xieta and weights
-  const eigen::DMat2N& xieta = spectrals::getXiEtaElement(axial());
-  const eigen::DRowN& weights = spectrals::getWeightsElement(axial());
+  const axisem3d::eigen::DMat2N& xieta = spectrals::getXiEtaElement(axial());
+  const axisem3d::eigen::DRowN& weights = spectrals::getWeightsElement(axial());
 
   // compute integral factor
-  eigen::DRowN ifact;
+  axisem3d::eigen::DRowN ifact;
   for (int ipnt = 0; ipnt < spectral::nPEM; ipnt++) {
     // element Jacobian
     J[ipnt] = mMapping->jacobian(xieta.col(ipnt));
@@ -422,12 +423,12 @@ Quad::computeIntegralFactor(eigen::DMat2N& sz, std::array<eigen::DMat22, spectra
 // get normal
 void
 Quad::computeNormal(int edge,
-    const eigen::DMat2N& sz,
-    const std::array<eigen::DMat22, spectral::nPEM>& J,
+    const axisem3d::eigen::DMat2N& sz,
+    const std::array<axisem3d::eigen::DMat22, spectral::nPEM>& J,
     std::vector<int>& ipnts,
-    eigen::arP_DMatX3& normal) const {
+    axisem3d::eigen::arP_DMatX3& normal) const {
   // xieta
-  const eigen::DMat2N& xieta = spectrals::getXiEtaElement(axial());
+  const axisem3d::eigen::DMat2N& xieta = spectrals::getXiEtaElement(axial());
 
   // points on edge
   ipnts = vicinity::constants::gEdgeIPnt[edge];
@@ -436,7 +437,7 @@ Quad::computeNormal(int edge,
   for (int ip = 0; ip < spectral::nPED; ip++) {
     int ipnt = ipnts[ip];
     // 1D normal
-    eigen::DCol2 n1D = mMapping->normal(edge, J[ipnt]);
+    axisem3d::eigen::DCol2 n1D = mMapping->normal(edge, J[ipnt]);
     // integral weights
     int ipol = ipnt / spectral::nPED;
     int jpol = ipnt % spectral::nPED;
@@ -471,10 +472,10 @@ Quad::computeNormal(int edge,
 }
 
 // weights for CG4 attenuation
-eigen::DRow4
-Quad::computeWeightsCG4(const eigen::DMatPP_RM& ifPP) const {
+axisem3d::eigen::DRow4
+Quad::computeWeightsCG4(const axisem3d::eigen::DMatPP_RM& ifPP) const {
   if (spectral::nPol != 4) {
-    return eigen::DRow4::Zero();
+    return axisem3d::eigen::DRow4::Zero();
   }
   // weights on CG4 points (marked O)
   // x x x x x
@@ -482,7 +483,7 @@ Quad::computeWeightsCG4(const eigen::DMatPP_RM& ifPP) const {
   // x x x x x
   // x O x O x
   // x x x x x
-  eigen::DRow4 wcg4;
+  axisem3d::eigen::DRow4 wcg4;
   wcg4(0) = (ifPP(0, 0) + ifPP(0, 1) + ifPP(1, 0) + ifPP(1, 1) +
                 0.50 * (ifPP(0, 2) + ifPP(1, 2) + ifPP(2, 0) + ifPP(2, 1)) + 0.25 * ifPP(2, 2)) /
       ifPP(1, 1);

--- a/src/preloop/se_model/quad/Quad.hpp
+++ b/src/preloop/se_model/quad/Quad.hpp
@@ -66,7 +66,7 @@ class Quad {
   computeDt(double courant, const ABC& abc) const;
 
   // get nodal sz
-  const eigen::DMat24&
+  const axisem3d::eigen::DMat24&
   getNodalSZ() const {
     return mMapping->getNodalSZ();
   }
@@ -81,8 +81,8 @@ class Quad {
   // inverse mapping: (s,z) -> (ξ,η)
   // return true if (s,z) is inside this element
   bool
-  inverseMapping(const eigen::DCol2& sz,
-      eigen::DCol2& xieta,
+  inverseMapping(const axisem3d::eigen::DCol2& sz,
+      axisem3d::eigen::DCol2& xieta,
       double maxIter = 10,
       double tolerance = 1e-9) const {
     return mMapping->inverseMapping(sz, xieta, maxIter, tolerance);
@@ -91,20 +91,21 @@ class Quad {
   private:
   //////////////////////// interal ////////////////////////
   // compute integral factor
-  eigen::DRowN
-  computeIntegralFactor(eigen::DMat2N& sz, std::array<eigen::DMat22, spectral::nPEM>& J) const;
+  axisem3d::eigen::DRowN
+  computeIntegralFactor(
+      axisem3d::eigen::DMat2N& sz, std::array<axisem3d::eigen::DMat22, spectral::nPEM>& J) const;
 
   // get normal
   void
   computeNormal(int edge,
-      const eigen::DMat2N& sz,
-      const std::array<eigen::DMat22, spectral::nPEM>& J,
+      const axisem3d::eigen::DMat2N& sz,
+      const std::array<axisem3d::eigen::DMat22, spectral::nPEM>& J,
       std::vector<int>& ipnts,
-      eigen::arP_DMatX3& normal) const;
+      axisem3d::eigen::arP_DMatX3& normal) const;
 
   // weights for CG4 attenuation
-  eigen::DRow4
-  computeWeightsCG4(const eigen::DMatPP_RM& ifPP) const;
+  axisem3d::eigen::DRow4
+  computeWeightsCG4(const axisem3d::eigen::DMatPP_RM& ifPP) const;
 
   public:
   //////////////////////// get ////////////////////////
@@ -115,16 +116,16 @@ class Quad {
   }
 
   // get point nr
-  inline const eigen::IRowN&
+  inline const axisem3d::eigen::IRowN&
   getPointNr() const {
     return *mPointNr;
   }
 
   // get point sz
-  eigen::DMat2N
+  axisem3d::eigen::DMat2N
   getPointSZ() const {
-    eigen::DMat2N pointSZ;
-    const eigen::DMat2N& xieta = spectrals::getXiEtaElement(axial());
+    axisem3d::eigen::DMat2N pointSZ;
+    const axisem3d::eigen::DMat2N& xieta = spectrals::getXiEtaElement(axial());
     for (int ipnt = 0; ipnt < spectral::nPEM; ipnt++) {
       pointSZ.col(ipnt) = mMapping->mapping(xieta.col(ipnt));
     }
@@ -132,7 +133,7 @@ class Quad {
   }
 
   // get undulation
-  eigen::arN_DColX
+  axisem3d::eigen::arN_DColX
   getUndulation() const {
     return mUndulation->getPointwise();
   }
@@ -176,15 +177,15 @@ class Quad {
   // create gradient
   template <typename floatT>
   std::unique_ptr<const GradientQuadrature<floatT>>
-  createGradient(eigen::DMat2N& sz, eigen::DMatPP_RM& ifPP) const {
+  createGradient(axisem3d::eigen::DMat2N& sz, axisem3d::eigen::DMatPP_RM& ifPP) const {
     // integral factor
-    static std::array<eigen::DMat22, spectral::nPEM> J;
-    const eigen::DRowN& ifact = computeIntegralFactor(sz, J);
+    static std::array<axisem3d::eigen::DMat22, spectral::nPEM> J;
+    const axisem3d::eigen::DRowN& ifact = computeIntegralFactor(sz, J);
     // save integral factor for later use (CG4)
-    ifPP = Eigen::Map<const eigen::DMatPP_RM>(ifact.data());
+    ifPP = Eigen::Map<const axisem3d::eigen::DMatPP_RM>(ifact.data());
 
     // compute Jacobian and s^-1
-    static eigen::DMatPP_RM dsdxii, dsdeta, dzdxii, dzdeta, inv_s;
+    static axisem3d::eigen::DMatPP_RM dsdxii, dsdeta, dzdxii, dzdeta, inv_s;
     for (int ipol = 0; ipol < spectral::nPED; ipol++) {
       for (int jpol = 0; jpol < spectral::nPED; jpol++) {
         int ipnt = ipol * spectral::nPED + jpol;
@@ -232,7 +233,7 @@ class Quad {
   std::map<std::string, int> mEdgesOnBoundary;
 
   // nr field
-  std::unique_ptr<eigen::IRowN> mPointNr = nullptr;
+  std::unique_ptr<axisem3d::eigen::IRowN> mPointNr = nullptr;
 
   ////////////// components //////////////
   // mapping

--- a/src/preloop/se_model/quad/mapping/Mapping.hpp
+++ b/src/preloop/se_model/quad/mapping/Mapping.hpp
@@ -18,9 +18,9 @@
 class Mapping {
   public:
   // constructor
-  Mapping(const eigen::DMat24& nodalSZ) : mNodalSZ(nodalSZ) {
+  Mapping(const axisem3d::eigen::DMat24& nodalSZ) : mNodalSZ(nodalSZ) {
     // minimum edge length
-    eigen::DRow4 edgeLength;
+    axisem3d::eigen::DRow4 edgeLength;
     edgeLength(0) = (nodalSZ.col(0) - nodalSZ.col(1)).norm();
     edgeLength(1) = (nodalSZ.col(1) - nodalSZ.col(2)).norm();
     edgeLength(2) = (nodalSZ.col(2) - nodalSZ.col(3)).norm();
@@ -32,18 +32,18 @@ class Mapping {
   virtual ~Mapping() = default;
 
   // forward mapping: (ξ,η) -> (s,z)
-  virtual eigen::DCol2
-  mapping(const eigen::DCol2& xieta) const = 0;
+  virtual axisem3d::eigen::DCol2
+  mapping(const axisem3d::eigen::DCol2& xieta) const = 0;
 
   // Jacobian: ∂(s,z) / ∂(ξ,η)
-  virtual eigen::DMat22
-  jacobian(const eigen::DCol2& xieta) const = 0;
+  virtual axisem3d::eigen::DMat22
+  jacobian(const axisem3d::eigen::DCol2& xieta) const = 0;
 
   // inverse mapping: (s,z) -> (ξ,η)
   // return true if (s,z) is inside this element
   bool
-  inverseMapping(const eigen::DCol2& sz,
-      eigen::DCol2& xieta,
+  inverseMapping(const axisem3d::eigen::DCol2& sz,
+      axisem3d::eigen::DCol2& xieta,
       double maxIter = 10,
       double tolerance = 1e-9) const {
     // Newton
@@ -51,7 +51,7 @@ class Mapping {
     double absSZ = tolerance * mMinEdgeLength;
     int iter = 0;
     for (; iter < maxIter; iter++) {
-      const eigen::DCol2& dsz = sz - mapping(xieta);
+      const axisem3d::eigen::DCol2& dsz = sz - mapping(xieta);
       if (dsz.norm() < absSZ) {
         break;
       }
@@ -69,9 +69,9 @@ class Mapping {
   }
 
   // normal
-  eigen::DCol2
-  normal(int edge, const eigen::DMat22& J) const {
-    eigen::DCol2 normal;
+  axisem3d::eigen::DCol2
+  normal(int edge, const axisem3d::eigen::DMat22& J) const {
+    axisem3d::eigen::DCol2 normal;
     if (edge == 0) {
       // xi increases from -1 to 1, eta = -1
       // n = (0, 1, 0) x (ds/dxi, 0, dz/dxi)
@@ -97,7 +97,7 @@ class Mapping {
   }
 
   // get nodal coordinates
-  const eigen::DMat24&
+  const axisem3d::eigen::DMat24&
   getNodalSZ() const {
     return mNodalSZ;
   }
@@ -111,10 +111,10 @@ class Mapping {
   protected:
   // rotate CS such that mCurvedOuter lies on edge 2
   void
-  rotateQ2(const eigen::DCol2& xieta,
-      eigen::DMat24& szQ2,
-      eigen::DMat24& rtQ2,
-      eigen::DCol2& xietaQ2) const {
+  rotateQ2(const axisem3d::eigen::DCol2& xieta,
+      axisem3d::eigen::DMat24& szQ2,
+      axisem3d::eigen::DMat24& rtQ2,
+      axisem3d::eigen::DCol2& xietaQ2) const {
     // direct multiplication for sz and xieta
     szQ2 = sOrthogQ2[mCurvedOuter] * mNodalSZ;
     xietaQ2 = sOrthogQ2[mCurvedOuter] * xieta;
@@ -132,7 +132,7 @@ class Mapping {
   ////////////////////////////// data //////////////////////////////
   protected:
   // nodal coordinates
-  const eigen::DMat24 mNodalSZ;
+  const axisem3d::eigen::DMat24 mNodalSZ;
 
   // minimum edge length
   double mMinEdgeLength = 0.;
@@ -169,11 +169,11 @@ class Mapping {
   }
 
   // coordinate rotation matrix Q2
-  inline static std::array<eigen::DMat22, 4> sOrthogQ2 = {
-      (eigen::DMat22(2, 2) << -1., 0., 0., -1.).finished(),
-      (eigen::DMat22(2, 2) << 0., -1., 1., 0.).finished(),
-      (eigen::DMat22(2, 2) << 1., 0., 0., 1.).finished(),
-      (eigen::DMat22(2, 2) << 0., 1., -1., 0.).finished()};
+  inline static std::array<axisem3d::eigen::DMat22, 4> sOrthogQ2 = {
+      (axisem3d::eigen::DMat22(2, 2) << -1., 0., 0., -1.).finished(),
+      (axisem3d::eigen::DMat22(2, 2) << 0., -1., 1., 0.).finished(),
+      (axisem3d::eigen::DMat22(2, 2) << 1., 0., 0., 1.).finished(),
+      (axisem3d::eigen::DMat22(2, 2) << 0., 1., -1., 0.).finished()};
 };
 
 #endif /* Mapping_hpp */

--- a/src/preloop/se_model/quad/mapping/MappingLinear.hpp
+++ b/src/preloop/se_model/quad/mapping/MappingLinear.hpp
@@ -17,16 +17,16 @@
 class MappingLinear : public Mapping {
   public:
   // constructor
-  MappingLinear(const eigen::DMat24& nodalSZ) : Mapping(nodalSZ) {
+  MappingLinear(const axisem3d::eigen::DMat24& nodalSZ) : Mapping(nodalSZ) {
     // undefined curved outer
     mCurvedOuter = -1;
   }
 
   // forward mapping: (ξ,η) -> (s,z)
-  eigen::DCol2
-  mapping(const eigen::DCol2& xieta) const {
+  axisem3d::eigen::DCol2
+  mapping(const axisem3d::eigen::DCol2& xieta) const {
     // shape function
-    eigen::DRow4 shp;
+    axisem3d::eigen::DRow4 shp;
     double xip = 1. + xieta(0);
     double xim = 1. - xieta(0);
     double etp = 1. + xieta(1);
@@ -39,10 +39,10 @@ class MappingLinear : public Mapping {
   }
 
   // Jacobian: ∂(s,z) / ∂(ξ,η)
-  eigen::DMat22
-  jacobian(const eigen::DCol2& xieta) const {
+  axisem3d::eigen::DMat22
+  jacobian(const axisem3d::eigen::DCol2& xieta) const {
     // derivative of shape function
-    eigen::DMat24 dshp;
+    axisem3d::eigen::DMat24 dshp;
     double xip = 1. + xieta(0);
     double xim = 1. - xieta(0);
     double etp = 1. + xieta(1);

--- a/src/preloop/se_model/quad/mapping/MappingSemiSpherical.hpp
+++ b/src/preloop/se_model/quad/mapping/MappingSemiSpherical.hpp
@@ -15,7 +15,7 @@
 class MappingSemiSpherical : public Mapping {
   public:
   // constructor
-  MappingSemiSpherical(const eigen::DMat24& nodalSZ) : Mapping(nodalSZ) {
+  MappingSemiSpherical(const axisem3d::eigen::DMat24& nodalSZ) : Mapping(nodalSZ) {
     // find curved outer
     const auto& r = nodalSZ.colwise().norm();
     double distTol = mMinEdgeLength * 1e-3;
@@ -34,8 +34,8 @@ class MappingSemiSpherical : public Mapping {
   }
 
   // forward mapping: (ξ,η) -> (s,z)
-  eigen::DCol2
-  mapping(const eigen::DCol2& xieta) const {
+  axisem3d::eigen::DCol2
+  mapping(const axisem3d::eigen::DCol2& xieta) const {
     // compute coords rotated by Q2
     double s0, z0, s1, z1, r2, t2, t3, xi, eta;
     computeCoordsQ2(xieta, s0, z0, s1, z1, r2, t2, t3, xi, eta);
@@ -48,7 +48,7 @@ class MappingSemiSpherical : public Mapping {
     double r2p = (1. + eta) * r2 * .5;
 
     // compute in new system
-    eigen::DCol2 sz;
+    axisem3d::eigen::DCol2 sz;
     sz(0) = etam * s01 + r2p * sin(t32);
     sz(1) = etam * z01 + r2p * cos(t32);
 
@@ -57,8 +57,8 @@ class MappingSemiSpherical : public Mapping {
   }
 
   // Jacobian: ∂(s,z) / ∂(ξ,η)
-  eigen::DMat22
-  jacobian(const eigen::DCol2& xieta) const {
+  axisem3d::eigen::DMat22
+  jacobian(const axisem3d::eigen::DCol2& xieta) const {
     // compute coords rotated by Q2
     double s0, z0, s1, z1, r2, t2, t3, xi, eta;
     computeCoordsQ2(xieta, s0, z0, s1, z1, r2, t2, t3, xi, eta);
@@ -77,21 +77,21 @@ class MappingSemiSpherical : public Mapping {
     double r2p_eta = r2 * .5;
 
     // compute in new system
-    eigen::DMat22 J;
+    axisem3d::eigen::DMat22 J;
     J(0, 0) = etam * s01_xi + r2p * cos(t32) * t32_xi;
     J(1, 0) = etam * z01_xi - r2p * sin(t32) * t32_xi;
     J(0, 1) = etam_eta * s01 + r2p_eta * sin(t32);
     J(1, 1) = etam_eta * z01 + r2p_eta * cos(t32);
 
     // rotate back
-    const eigen::DMat22& Q2 = sOrthogQ2[mCurvedOuter];
+    const axisem3d::eigen::DMat22& Q2 = sOrthogQ2[mCurvedOuter];
     return Q2.transpose() * J * Q2;
   }
 
   private:
   // compute coords rotated by Q2
   void
-  computeCoordsQ2(const eigen::DCol2& xieta,
+  computeCoordsQ2(const axisem3d::eigen::DCol2& xieta,
       double& s0,
       double& z0,
       double& s1,
@@ -102,8 +102,8 @@ class MappingSemiSpherical : public Mapping {
       double& xi,
       double& eta) const {
     // rotate CS such that mCurvedOuter lies on edge 2
-    static eigen::DMat24 szQ2, rtQ2;
-    static eigen::DCol2 xietaQ2;
+    static axisem3d::eigen::DMat24 szQ2, rtQ2;
+    static axisem3d::eigen::DCol2 xietaQ2;
     rotateQ2(xieta, szQ2, rtQ2, xietaQ2);
 
     // the coords are not permutated, so edge 2 should be

--- a/src/preloop/se_model/quad/mapping/MappingSpherical.hpp
+++ b/src/preloop/se_model/quad/mapping/MappingSpherical.hpp
@@ -17,7 +17,7 @@
 class MappingSpherical : public Mapping {
   public:
   // constructor
-  MappingSpherical(const eigen::DMat24& nodalSZ) : Mapping(nodalSZ) {
+  MappingSpherical(const axisem3d::eigen::DMat24& nodalSZ) : Mapping(nodalSZ) {
     // find curved outer
     const auto& r = nodalSZ.colwise().norm();
     double distTol = mMinEdgeLength * 1e-3;
@@ -32,8 +32,8 @@ class MappingSpherical : public Mapping {
   }
 
   // forward mapping: (ξ,η) -> (s,z)
-  eigen::DCol2
-  mapping(const eigen::DCol2& xieta) const {
+  axisem3d::eigen::DCol2
+  mapping(const axisem3d::eigen::DCol2& xieta) const {
     // compute coords rotated by Q2
     double r0, r2, t0, t1, t2, t3, xi, eta;
     computeCoordsQ2(xieta, r0, r2, t0, t1, t2, t3, xi, eta);
@@ -45,7 +45,7 @@ class MappingSpherical : public Mapping {
     double r2p = (1. + eta) * r2 * .5;
 
     // compute in new system
-    eigen::DCol2 sz;
+    axisem3d::eigen::DCol2 sz;
     sz(0) = r0m * sin(t01) + r2p * sin(t32);
     sz(1) = r0m * cos(t01) + r2p * cos(t32);
 
@@ -54,8 +54,8 @@ class MappingSpherical : public Mapping {
   }
 
   // Jacobian: ∂(s,z) / ∂(ξ,η)
-  eigen::DMat22
-  jacobian(const eigen::DCol2& xieta) const {
+  axisem3d::eigen::DMat22
+  jacobian(const axisem3d::eigen::DCol2& xieta) const {
     // compute coords rotated by Q2
     double r0, r2, t0, t1, t2, t3, xi, eta;
     computeCoordsQ2(xieta, r0, r2, t0, t1, t2, t3, xi, eta);
@@ -72,21 +72,21 @@ class MappingSpherical : public Mapping {
     double r2p_eta = r2 * .5;
 
     // compute in new system
-    eigen::DMat22 J;
+    axisem3d::eigen::DMat22 J;
     J(0, 0) = (r0m * cos(t01) * t01_xi + r2p * cos(t32) * t32_xi);
     J(1, 0) = (r0m * sin(t01) * t01_xi + r2p * sin(t32) * t32_xi) * (-1.);
     J(0, 1) = r0m_eta * sin(t01) + r2p_eta * sin(t32);
     J(1, 1) = r0m_eta * cos(t01) + r2p_eta * cos(t32);
 
     // rotate back
-    const eigen::DMat22& Q2 = sOrthogQ2[mCurvedOuter];
+    const axisem3d::eigen::DMat22& Q2 = sOrthogQ2[mCurvedOuter];
     return Q2.transpose() * J * Q2;
   }
 
   private:
   // compute coords rotated by Q2
   void
-  computeCoordsQ2(const eigen::DCol2& xieta,
+  computeCoordsQ2(const axisem3d::eigen::DCol2& xieta,
       double& r0,
       double& r2,
       double& t0,
@@ -96,8 +96,8 @@ class MappingSpherical : public Mapping {
       double& xi,
       double& eta) const {
     // rotate CS such that mCurvedOuter lies on edge 2
-    static eigen::DMat24 szQ2, rtQ2;
-    static eigen::DCol2 xietaQ2;
+    static axisem3d::eigen::DMat24 szQ2, rtQ2;
+    static axisem3d::eigen::DCol2 xietaQ2;
     rotateQ2(xieta, szQ2, rtQ2, xietaQ2);
 
     // the coords are not permutated, so edge 2 should be

--- a/src/preloop/se_model/quad/physical/AttBuilder.cpp
+++ b/src/preloop/se_model/quad/physical/AttBuilder.cpp
@@ -29,7 +29,7 @@ AttBuilder::AttBuilder(const ExodusMesh& exodusMesh, bool cg4, double dt) :
     mFref(exodusMesh.getGlobalVariable("attenuation_f_ref")),
     mNSLS(exodusMesh.getGlobalVariable("nr_lin_solids")), mUseCG4(cg4), mDt(dt) {
   timer::gPreloopTimer.begin("Creating attenuation builder");
-  mW = mY = eigen::DColX(mNSLS);
+  mW = mY = axisem3d::eigen::DColX(mNSLS);
   for (int isls = 0; isls < mNSLS; isls++) {
     mW[isls] = exodusMesh.getGlobalVariable("attenuation_w_" + bstring::toString(isls));
     mY[isls] = exodusMesh.getGlobalVariable("attenuation_y_" + bstring::toString(isls));
@@ -101,11 +101,11 @@ AttBuilder::verbose(const std::unique_ptr<const AttBuilder>& attBuilder) {
 
 // create attenuation
 std::unique_ptr<Attenuation>
-AttBuilder::createAttenuation(const eigen::DMatXN& QKp,
-    const eigen::DMatXN& QMu,
-    eigen::DMatXN& kp,
-    eigen::DMatXN& mu,
-    const eigen::DRow4& weightsCG4,
+AttBuilder::createAttenuation(const axisem3d::eigen::DMatXN& QKp,
+    const axisem3d::eigen::DMatXN& QMu,
+    axisem3d::eigen::DMatXN& kp,
+    axisem3d::eigen::DMatXN& mu,
+    const axisem3d::eigen::DRow4& weightsCG4,
     bool elastic1D) const {
   // constants
   static double ysum = mY.sum();
@@ -114,28 +114,28 @@ AttBuilder::createAttenuation(const eigen::DMatXN& QKp,
   static double w10f = 2. * log(w1 / w0) / numerical::dPi;
   static double fact =
       (mY.array() * mW.array().square() / (mW.array().square() + w1 * w1)).sum() / ysum;
-  const eigen::DMatXN& ones = eigen::DMatXN::Ones(QKp.rows(), QKp.cols());
+  const axisem3d::eigen::DMatXN& ones = axisem3d::eigen::DMatXN::Ones(QKp.rows(), QKp.cols());
 
   // kappa
-  const eigen::DMatXN& kpNA = ones + w10f * QKp.cwiseInverse();
-  eigen::DMatXN dkp = kpNA.cwiseQuotient(QKp / ysum + (1. - fact) * ones);
-  const eigen::DMatXN& kpAT = kpNA + dkp * fact;
+  const axisem3d::eigen::DMatXN& kpNA = ones + w10f * QKp.cwiseInverse();
+  axisem3d::eigen::DMatXN dkp = kpNA.cwiseQuotient(QKp / ysum + (1. - fact) * ones);
+  const axisem3d::eigen::DMatXN& kpAT = kpNA + dkp * fact;
   dkp.array() *= kp.array();
 
   // mu
-  const eigen::DMatXN& muNA = ones + w10f * QMu.cwiseInverse();
-  eigen::DMatXN dmu = muNA.cwiseQuotient(QMu / ysum + (1. - fact) * ones);
-  const eigen::DMatXN& muAT = muNA + dmu * fact;
+  const axisem3d::eigen::DMatXN& muNA = ones + w10f * QMu.cwiseInverse();
+  axisem3d::eigen::DMatXN dmu = muNA.cwiseQuotient(QMu / ysum + (1. - fact) * ones);
+  const axisem3d::eigen::DMatXN& muAT = muNA + dmu * fact;
   dmu.array() *= mu.array();
 
   // lambda
-  const eigen::DMatXN& dlm = dkp - (2. / 3.) * dmu;
+  const axisem3d::eigen::DMatXN& dlm = dkp - (2. / 3.) * dmu;
 
   // 1D or 3D
   if (mUseCG4) {
     // extract CG4 from full
     int nr = (int)dlm.rows();
-    eigen::DMatX4 dlm4(nr, 4), dmu4(nr, 4);
+    axisem3d::eigen::DMatX4 dlm4(nr, 4), dmu4(nr, 4);
     const std::vector<int> ipols = {1, 1, 3, 3};
     const std::vector<int> jpols = {1, 3, 1, 3};
     for (int ip4 = 0; ip4 < 4; ip4++) {
@@ -149,7 +149,7 @@ AttBuilder::createAttenuation(const eigen::DMatXN& QKp,
     // factor = NA                        , on other points
     kp.array() *= kpNA.array();
     mu.array() *= muNA.array();
-    const auto& ones = eigen::DColX::Ones(nr).array();
+    const auto& ones = axisem3d::eigen::DColX::Ones(nr).array();
     for (int ip4 = 0; ip4 < 4; ip4++) {
       int ipnt = ipols[ip4] * spectral::nPED + jpols[ip4];
       kp.col(ipnt).array() *=
@@ -161,8 +161,8 @@ AttBuilder::createAttenuation(const eigen::DMatXN& QKp,
     // return
     if (elastic1D) {
       return std::make_unique<AttenuationCG4>(
-          Eigen::Map<const eigen::DMat22_RM>(dlm4.data()).eval(),
-          Eigen::Map<const eigen::DMat22_RM>(dmu4.data()).eval());
+          Eigen::Map<const axisem3d::eigen::DMat22_RM>(dlm4.data()).eval(),
+          Eigen::Map<const axisem3d::eigen::DMat22_RM>(dmu4.data()).eval());
     } else {
       return std::make_unique<AttenuationCG4>(dlm4, dmu4);
     }
@@ -184,15 +184,17 @@ AttBuilder::createAttenuation(const eigen::DMatXN& QKp,
 void
 AttBuilder::setAlphaBetaGamma() const {
   // constants
-  const eigen::DColX& yUn = mY / mY.sum();
-  const eigen::DColX& wDt = mW * mDt;
-  const eigen::DColX& nSLS1 = eigen::DColX::Ones(mNSLS);
+  const axisem3d::eigen::DColX& yUn = mY / mY.sum();
+  const axisem3d::eigen::DColX& wDt = mW * mDt;
+  const axisem3d::eigen::DColX& nSLS1 = axisem3d::eigen::DColX::Ones(mNSLS);
   // alpha
-  const eigen::DColX& alpha = (-wDt).array().exp();
+  const axisem3d::eigen::DColX& alpha = (-wDt).array().exp();
   // beta
-  const eigen::DColX& betta = yUn.cwiseProduct((nSLS1 - alpha).cwiseQuotient(wDt) - alpha);
+  const axisem3d::eigen::DColX& betta =
+      yUn.cwiseProduct((nSLS1 - alpha).cwiseQuotient(wDt) - alpha);
   // gamma
-  const eigen::DColX& gamma = yUn.cwiseProduct((alpha - nSLS1).cwiseQuotient(wDt) + nSLS1);
+  const axisem3d::eigen::DColX& gamma =
+      yUn.cwiseProduct((alpha - nSLS1).cwiseQuotient(wDt) + nSLS1);
   // set statics in Attenuation
   Attenuation::setAlphaBetaGamma(alpha, betta, gamma);
 }

--- a/src/preloop/se_model/quad/physical/AttBuilder.hpp
+++ b/src/preloop/se_model/quad/physical/AttBuilder.hpp
@@ -28,11 +28,11 @@ class AttBuilder {
 
   // create attenuation
   std::unique_ptr<Attenuation>
-  createAttenuation(const eigen::DMatXN& QKp,
-      const eigen::DMatXN& QMu,
-      eigen::DMatXN& kp,
-      eigen::DMatXN& mu,
-      const eigen::DRow4& weightsCG4,
+  createAttenuation(const axisem3d::eigen::DMatXN& QKp,
+      const axisem3d::eigen::DMatXN& QMu,
+      axisem3d::eigen::DMatXN& kp,
+      axisem3d::eigen::DMatXN& mu,
+      const axisem3d::eigen::DRow4& weightsCG4,
       bool elastic1D) const;
 
   private:
@@ -46,7 +46,7 @@ class AttBuilder {
   // from Exodus
   const double mFmin, mFmax, mFref;
   const int mNSLS;
-  eigen::DColX mW, mY;
+  axisem3d::eigen::DColX mW, mY;
 
   // from inparam
   const bool mUseCG4;

--- a/src/preloop/se_model/quad/physical/Material.cpp
+++ b/src/preloop/se_model/quad/physical/Material.cpp
@@ -25,13 +25,14 @@
 
 ////////////////////////// input //////////////////////////
 // constructor
-Material::Material(const ExodusMesh& exodusMesh, const eigen::DMat24& nodalSZ, bool axial) {
+Material::Material(
+    const ExodusMesh& exodusMesh, const axisem3d::eigen::DMat24& nodalSZ, bool axial) {
   // get radial coords and variables from mesh
   const auto& radialCoords = exodusMesh.getRadialCoords();
   const auto& radialVariables = exodusMesh.getRadialVariables();
 
   // radial coords of me
-  const eigen::DRow4& r =
+  const axisem3d::eigen::DRow4& r =
       geodesy::isCartesian() ? nodalSZ.row(1).eval() : nodalSZ.colwise().norm().eval();
 
   // locate center in radial profile
@@ -46,11 +47,11 @@ Material::Material(const ExodusMesh& exodusMesh, const eigen::DMat24& nodalSZ, b
   bool fluid = false;
   for (auto it = radialVariables.begin(); it != radialVariables.end(); ++it) {
     // end points
-    const eigen::DColX& rvals = it->second;
+    const axisem3d::eigen::DColX& rvals = it->second;
     double v0 = rvals(index0);
     double v1 = rvals(index1);
     // interpolation
-    const eigen::DRow4& nvals = (v1 - v0) / (r1 - r0) * (r.array() - r0) + v0;
+    const axisem3d::eigen::DRow4& nvals = (v1 - v0) / (r1 - r0) * (r.array() - r0) + v0;
     // add to map
     mProperties.insert({it->first, NodalPhysicalProperty(nvals, axial)});
     // check fluid
@@ -64,10 +65,10 @@ Material::Material(const ExodusMesh& exodusMesh, const eigen::DMat24& nodalSZ, b
   // reduce to fluid
   if (fluid) {
     // get vp and rho
-    const eigen::DRow4& vp =
+    const axisem3d::eigen::DRow4& vp =
         (mProperties.find("VPV") != mProperties.end() ? mProperties.at("VPV").getNodalData()
                                                       : mProperties.at("VP").getNodalData());
-    const eigen::DRow4& rho = mProperties.at("RHO").getNodalData();
+    const axisem3d::eigen::DRow4& rho = mProperties.at("RHO").getNodalData();
     // clear all properties
     mProperties.clear();
     // only save vp and rho
@@ -77,15 +78,15 @@ Material::Material(const ExodusMesh& exodusMesh, const eigen::DMat24& nodalSZ, b
 
   // reduce TISO to ISO if possible
   if (currentRheology() == RheologyType::TISO) {
-    const eigen::DRow4& vpv = mProperties.at("VPV").getNodalData();
-    const eigen::DRow4& vph = mProperties.at("VPH").getNodalData();
-    const eigen::DRow4& vsv = mProperties.at("VSV").getNodalData();
-    const eigen::DRow4& vsh = mProperties.at("VSH").getNodalData();
-    const eigen::DRow4& eta = mProperties.at("ETA").getNodalData();
+    const axisem3d::eigen::DRow4& vpv = mProperties.at("VPV").getNodalData();
+    const axisem3d::eigen::DRow4& vph = mProperties.at("VPH").getNodalData();
+    const axisem3d::eigen::DRow4& vsv = mProperties.at("VSV").getNodalData();
+    const axisem3d::eigen::DRow4& vsh = mProperties.at("VSH").getNodalData();
+    const axisem3d::eigen::DRow4& eta = mProperties.at("ETA").getNodalData();
     // TISO to ISO
     if ((vpv - vph).norm() < vpv.norm() * numerical::dEpsilon &&
         (vsv - vsh).norm() < vsv.norm() * numerical::dEpsilon &&
-        (eta - eigen::DRow4::Ones()).norm() < 2. * numerical::dEpsilon) {
+        (eta - axisem3d::eigen::DRow4::Ones()).norm() < 2. * numerical::dEpsilon) {
       // add ISO
       mProperties.insert({"VP", NodalPhysicalProperty(vpv, axial)});
       mProperties.insert({"VS", NodalPhysicalProperty(vsv, axial)});
@@ -103,8 +104,8 @@ Material::Material(const ExodusMesh& exodusMesh, const eigen::DMat24& nodalSZ, b
 void
 Material::addProperty3D(const std::string& propKey,
     const Volumetric3D::ReferenceKind& refKind,
-    const eigen::arN_IColX& inScope,
-    const eigen::arN_DColX& propValue) {
+    const axisem3d::eigen::arN_IColX& inScope,
+    const axisem3d::eigen::arN_DColX& propValue) {
   // backward compatibility
   // TISO
   if (currentRheology() == RheologyType::TISO && (propKey == "VP" || propKey == "VS")) {
@@ -139,26 +140,26 @@ Material::addProperty3D(const std::string& propKey,
   }
 
   // compute 3D value
-  eigen::arN_DColX valNew;
+  axisem3d::eigen::arN_DColX valNew;
   if (refKind == Volumetric3D::ReferenceKind::ABS) {
     // absolute
     valNew = propValue;
   } else if (refKind == Volumetric3D::ReferenceKind::REF1D) {
     // 1D as reference
-    const eigen::arN_DColX& val1D = getProperty(propKey).getPointwiseNodal();
+    const axisem3d::eigen::arN_DColX& val1D = getProperty(propKey).getPointwiseNodal();
     for (int ipnt = 0; ipnt < spectral::nPEM; ipnt++) {
       op1D_3D::times((propValue[ipnt].array() + 1.).matrix(), val1D[ipnt], valNew[ipnt]);
     }
   } else if (refKind == Volumetric3D::ReferenceKind::REF3D) {
     // 3D as reference
-    const eigen::arN_DColX& val3D = getProperty(propKey).getPointwise();
+    const axisem3d::eigen::arN_DColX& val3D = getProperty(propKey).getPointwise();
     for (int ipnt = 0; ipnt < spectral::nPEM; ipnt++) {
       op1D_3D::times((propValue[ipnt].array() + 1.).matrix(), val3D[ipnt], valNew[ipnt]);
     }
   } else {
     // (3D - 1D) as reference
-    const eigen::arN_DColX& val1D = getProperty(propKey).getPointwiseNodal();
-    eigen::arN_DColX valPurterb = getProperty(propKey).getPointwise();
+    const axisem3d::eigen::arN_DColX& val1D = getProperty(propKey).getPointwiseNodal();
+    axisem3d::eigen::arN_DColX valPurterb = getProperty(propKey).getPointwise();
     for (int ipnt = 0; ipnt < spectral::nPEM; ipnt++) {
       op1D_3D::addTo(-val1D[ipnt], valPurterb[ipnt]);
       op1D_3D::times((propValue[ipnt].array() + 1.).matrix(), valPurterb[ipnt], valNew[ipnt]);
@@ -167,7 +168,7 @@ Material::addProperty3D(const std::string& propKey,
   }
 
   // out-of-scope mask
-  const eigen::arN_DColX& oriVal = getProperty(propKey).getPointwise();
+  const axisem3d::eigen::arN_DColX& oriVal = getProperty(propKey).getPointwise();
   for (int ipnt = 0; ipnt < spectral::nPEM; ipnt++) {
     if (oriVal[ipnt].rows() == 1) {
       valNew[ipnt] = inScope[ipnt].select(valNew[ipnt], oriVal[ipnt](0));
@@ -185,13 +186,13 @@ void
 Material::finished3D() {
   // try to degenerate TISO to ISO
   if (currentRheology() == RheologyType::TISO) {
-    eigen::DMatXN vpv = getElemental("VPV");
-    eigen::DMatXN vph = getElemental("VPH");
-    eigen::DMatXN vsv = getElemental("VSV");
-    eigen::DMatXN vsh = getElemental("VSH");
-    eigen::DMatXN eta = getElemental("ETA");
-    op1D_3D::regularize1D<eigen::DMatXN>({std::ref(vpv), std::ref(vph)});
-    op1D_3D::regularize1D<eigen::DMatXN>({std::ref(vsv), std::ref(vsh)});
+    axisem3d::eigen::DMatXN vpv = getElemental("VPV");
+    axisem3d::eigen::DMatXN vph = getElemental("VPH");
+    axisem3d::eigen::DMatXN vsv = getElemental("VSV");
+    axisem3d::eigen::DMatXN vsh = getElemental("VSH");
+    axisem3d::eigen::DMatXN eta = getElemental("ETA");
+    op1D_3D::regularize1D<axisem3d::eigen::DMatXN>({std::ref(vpv), std::ref(vph)});
+    op1D_3D::regularize1D<axisem3d::eigen::DMatXN>({std::ref(vsv), std::ref(vsh)});
     // TISO to ISO
     if ((vpv - vph).norm() < vpv.norm() * numerical::dEpsilon &&
         (vsv - vsh).norm() < vsv.norm() * numerical::dEpsilon &&
@@ -211,25 +212,25 @@ Material::finished3D() {
 
 ////////////////////////// output //////////////////////////
 // get maximum velocity for dt
-eigen::DMatXN
+axisem3d::eigen::DMatXN
 Material::getMaxVelocity() const {
   // three types of anisotropy
   if (currentRheology() == RheologyType::ANISO) {
     // get density and Cijkl
-    eigen::DMatXN rho = getElemental("RHO");
-    eigen::DMatXN C11 = getElemental("C11");
-    eigen::DMatXN C22 = getElemental("C22");
-    eigen::DMatXN C33 = getElemental("C33");
-    op1D_3D::regularize1D<eigen::DMatXN>(
+    axisem3d::eigen::DMatXN rho = getElemental("RHO");
+    axisem3d::eigen::DMatXN C11 = getElemental("C11");
+    axisem3d::eigen::DMatXN C22 = getElemental("C22");
+    axisem3d::eigen::DMatXN C33 = getElemental("C33");
+    op1D_3D::regularize1D<axisem3d::eigen::DMatXN>(
         {std::ref(rho), std::ref(C11), std::ref(C22), std::ref(C33)});
     // max of C11, C22, C33
-    const eigen::DMatXN& Cmax = C11.cwiseMax(C22).cwiseMax(C33);
+    const axisem3d::eigen::DMatXN& Cmax = C11.cwiseMax(C22).cwiseMax(C33);
     // vp = sqrt(Cmax / rho)
     return Cmax.cwiseQuotient(rho).cwiseSqrt();
   } else if (currentRheology() == RheologyType::TISO) {
-    eigen::DMatXN vpv = getElemental("VPV");
-    eigen::DMatXN vph = getElemental("VPH");
-    op1D_3D::regularize1D<eigen::DMatXN>({std::ref(vpv), std::ref(vph)});
+    axisem3d::eigen::DMatXN vpv = getElemental("VPV");
+    axisem3d::eigen::DMatXN vph = getElemental("VPH");
+    op1D_3D::regularize1D<axisem3d::eigen::DMatXN>({std::ref(vpv), std::ref(vph)});
     return vpv.cwiseMax(vph);
   } else {
     // ISO or fluid
@@ -239,8 +240,9 @@ Material::getMaxVelocity() const {
 
 // get rho, vp, vs for Clayton
 void
-Material::getPointwiseRhoVpVs(
-    eigen::arN_DColX& rho, eigen::arN_DColX& vp, eigen::arN_DColX& vs) const {
+Material::getPointwiseRhoVpVs(axisem3d::eigen::arN_DColX& rho,
+    axisem3d::eigen::arN_DColX& vp,
+    axisem3d::eigen::arN_DColX& vs) const {
   // density
   rho = getProperty("RHO").getPointwise();
 
@@ -257,7 +259,8 @@ Material::getPointwiseRhoVpVs(
   if (currentRheology() == RheologyType::FLUID) {
     vp = getProperty("VP").getPointwise();
     // vs = 0
-    vs = NodalPhysicalProperty(eigen::DRow4::Zero(), getProperty("RHO").axial()).getPointwise();
+    vs = NodalPhysicalProperty(axisem3d::eigen::DRow4::Zero(), getProperty("RHO").axial())
+             .getPointwise();
   } else if (currentRheology() == RheologyType::ANISO) {
     // get density and Cijkl
     const NodalPhysicalProperty& rh = mProperties.at("RHO");
@@ -303,9 +306,10 @@ Material::getPointwiseRhoVpVs(
 }
 
 // get mass for GLL-point setup
-eigen::arN_DColX
-Material::getMass(
-    const eigen::DRowN& integralFactor, const eigen::arN_DColX& jacobianPRT, bool fluid) const {
+axisem3d::eigen::arN_DColX
+Material::getMass(const axisem3d::eigen::DRowN& integralFactor,
+    const axisem3d::eigen::arN_DColX& jacobianPRT,
+    bool fluid) const {
   // check fluid
   if (fluid != (currentRheology() == RheologyType::FLUID)) {
     throw std::runtime_error("Material::getMass || "
@@ -313,11 +317,11 @@ Material::getMass(
   }
 
   // form density
-  eigen::arN_DColX mass;
+  axisem3d::eigen::arN_DColX mass;
   if (fluid) {
     // get rho and vp
-    const eigen::arN_DColX& rho = getPointwise("RHO");
-    const eigen::arN_DColX& vp = getPointwise("VP");
+    const axisem3d::eigen::arN_DColX& rho = getPointwise("RHO");
+    const axisem3d::eigen::arN_DColX& vp = getPointwise("VP");
     for (int ipnt = 0; ipnt < spectral::nPEM; ipnt++) {
       // kappa = rho * vp ** 2
       op1D_3D::times(rho[ipnt], vp[ipnt].array().square().matrix(), mass[ipnt]);
@@ -351,7 +355,7 @@ Material::createAcoustic() const {
                              "Incompatible solid/fluid flags.");
   }
   // K = 1 / rho
-  const eigen::DMatXN& K = getElemental("RHO").cwiseInverse();
+  const axisem3d::eigen::DMatXN& K = getElemental("RHO").cwiseInverse();
   // 1D or 3D
   if (K.rows() == 1) {
     return std::make_unique<Acoustic>(op1D_3D::toPP(K));
@@ -362,8 +366,8 @@ Material::createAcoustic() const {
 
 // create Elastic
 std::unique_ptr<Elastic>
-Material::createElastic(
-    const std::unique_ptr<const AttBuilder>& attBuilder, const eigen::DRow4& weightsCG4) const {
+Material::createElastic(const std::unique_ptr<const AttBuilder>& attBuilder,
+    const axisem3d::eigen::DRow4& weightsCG4) const {
   // check fluid
   if (currentRheology() == RheologyType::FLUID) {
     throw std::runtime_error("Material::createElastic || "
@@ -381,48 +385,48 @@ Material::createElastic(
 
 // anisotropic
 std::unique_ptr<Elastic>
-Material::createAnisotropic(
-    const std::unique_ptr<const AttBuilder>& attBuilder, const eigen::DRow4& weightsCG4) const {
+Material::createAnisotropic(const std::unique_ptr<const AttBuilder>& attBuilder,
+    const axisem3d::eigen::DRow4& weightsCG4) const {
   using op1D_3D::toPP;
   using std::ref;
 
   // Cijkl
   // C11
-  eigen::DMatXN C11 = getElemental("C11");
-  eigen::DMatXN C12 = getElemental("C12");
-  eigen::DMatXN C13 = getElemental("C13");
-  eigen::DMatXN C14 = getElemental("C14");
-  eigen::DMatXN C15 = getElemental("C15");
-  eigen::DMatXN C16 = getElemental("C16");
+  axisem3d::eigen::DMatXN C11 = getElemental("C11");
+  axisem3d::eigen::DMatXN C12 = getElemental("C12");
+  axisem3d::eigen::DMatXN C13 = getElemental("C13");
+  axisem3d::eigen::DMatXN C14 = getElemental("C14");
+  axisem3d::eigen::DMatXN C15 = getElemental("C15");
+  axisem3d::eigen::DMatXN C16 = getElemental("C16");
   // C22
-  eigen::DMatXN C22 = getElemental("C22");
-  eigen::DMatXN C23 = getElemental("C23");
-  eigen::DMatXN C24 = getElemental("C24");
-  eigen::DMatXN C25 = getElemental("C25");
-  eigen::DMatXN C26 = getElemental("C26");
+  axisem3d::eigen::DMatXN C22 = getElemental("C22");
+  axisem3d::eigen::DMatXN C23 = getElemental("C23");
+  axisem3d::eigen::DMatXN C24 = getElemental("C24");
+  axisem3d::eigen::DMatXN C25 = getElemental("C25");
+  axisem3d::eigen::DMatXN C26 = getElemental("C26");
   // C33
-  eigen::DMatXN C33 = getElemental("C33");
-  eigen::DMatXN C34 = getElemental("C34");
-  eigen::DMatXN C35 = getElemental("C35");
-  eigen::DMatXN C36 = getElemental("C36");
+  axisem3d::eigen::DMatXN C33 = getElemental("C33");
+  axisem3d::eigen::DMatXN C34 = getElemental("C34");
+  axisem3d::eigen::DMatXN C35 = getElemental("C35");
+  axisem3d::eigen::DMatXN C36 = getElemental("C36");
   // C44
-  eigen::DMatXN C44 = getElemental("C44");
-  eigen::DMatXN C45 = getElemental("C45");
-  eigen::DMatXN C46 = getElemental("C46");
+  axisem3d::eigen::DMatXN C44 = getElemental("C44");
+  axisem3d::eigen::DMatXN C45 = getElemental("C45");
+  axisem3d::eigen::DMatXN C46 = getElemental("C46");
   // C55
-  eigen::DMatXN C55 = getElemental("C55");
-  eigen::DMatXN C56 = getElemental("C56");
+  axisem3d::eigen::DMatXN C55 = getElemental("C55");
+  axisem3d::eigen::DMatXN C56 = getElemental("C56");
   // C66
-  eigen::DMatXN C66 = getElemental("C66");
+  axisem3d::eigen::DMatXN C66 = getElemental("C66");
 
   // attenuation
   std::unique_ptr<Attenuation> attenuation = nullptr;
   bool elastic1D = false;
   if (attBuilder) {
     // 1D or 3D
-    eigen::DMatXN QKp = getElemental("QKAPPA");
-    eigen::DMatXN QMu = getElemental("QMU");
-    elastic1D = op1D_3D::regularize1D<eigen::DMatXN>({ref(C11),
+    axisem3d::eigen::DMatXN QKp = getElemental("QKAPPA");
+    axisem3d::eigen::DMatXN QMu = getElemental("QMU");
+    elastic1D = op1D_3D::regularize1D<axisem3d::eigen::DMatXN>({ref(C11),
         ref(C12),
         ref(C13),
         ref(C14),
@@ -447,8 +451,9 @@ Material::createAnisotropic(
         ref(QMu)});
 
     // build attenuation
-    eigen::DMatXN kp = (C11 + C22 + C33 + (C12 + C23 + C13) * 2.) / 9.;
-    eigen::DMatXN mu = (C11 + C22 + C33 - (C12 + C23 + C13) + (C44 + C55 + C66) * 3.) / 15.;
+    axisem3d::eigen::DMatXN kp = (C11 + C22 + C33 + (C12 + C23 + C13) * 2.) / 9.;
+    axisem3d::eigen::DMatXN mu =
+        (C11 + C22 + C33 - (C12 + C23 + C13) + (C44 + C55 + C66) * 3.) / 15.;
     C11 -= (kp + 4. / 3. * mu);
     C22 -= (kp + 4. / 3. * mu);
     C33 -= (kp + 4. / 3. * mu);
@@ -470,7 +475,7 @@ Material::createAnisotropic(
     C66 += mu;
   } else {
     // 1D or 3D
-    elastic1D = op1D_3D::regularize1D<eigen::DMatXN>({ref(C11),
+    elastic1D = op1D_3D::regularize1D<axisem3d::eigen::DMatXN>({ref(C11),
         ref(C12),
         ref(C13),
         ref(C14),
@@ -545,42 +550,42 @@ Material::createAnisotropic(
 
 // transversely isotropic
 std::unique_ptr<Elastic>
-Material::createTISO(
-    const std::unique_ptr<const AttBuilder>& attBuilder, const eigen::DRow4& weightsCG4) const {
+Material::createTISO(const std::unique_ptr<const AttBuilder>& attBuilder,
+    const axisem3d::eigen::DRow4& weightsCG4) const {
   using op1D_3D::toPP;
   using std::ref;
 
   // density and velocity
-  const eigen::DMatXN& rho = getElemental("RHO");
-  const eigen::DMatXN& vpv = getElemental("VPV");
-  const eigen::DMatXN& vph = getElemental("VPH");
-  const eigen::DMatXN& vsv = getElemental("VSV");
-  const eigen::DMatXN& vsh = getElemental("VSH");
+  const axisem3d::eigen::DMatXN& rho = getElemental("RHO");
+  const axisem3d::eigen::DMatXN& vpv = getElemental("VPV");
+  const axisem3d::eigen::DMatXN& vph = getElemental("VPH");
+  const axisem3d::eigen::DMatXN& vsv = getElemental("VSV");
+  const axisem3d::eigen::DMatXN& vsh = getElemental("VSH");
 
   // A, C, F, L, N
-  eigen::DMatXN A, C, L, N;
+  axisem3d::eigen::DMatXN A, C, L, N;
   op1D_3D::times(rho, vph.array().square().matrix(), A);
   op1D_3D::times(rho, vpv.array().square().matrix(), C);
   op1D_3D::times(rho, vsv.array().square().matrix(), L);
   op1D_3D::times(rho, vsh.array().square().matrix(), N);
   // F = eta * (A - 2 L)
-  eigen::DMatXN eta = getElemental("ETA");
-  op1D_3D::regularize1D<eigen::DMatXN>({ref(A), ref(L), ref(eta)});
-  eigen::DMatXN F = eta.cwiseProduct(A - 2. * L);
+  axisem3d::eigen::DMatXN eta = getElemental("ETA");
+  op1D_3D::regularize1D<axisem3d::eigen::DMatXN>({ref(A), ref(L), ref(eta)});
+  axisem3d::eigen::DMatXN F = eta.cwiseProduct(A - 2. * L);
 
   // attenuation
   std::unique_ptr<Attenuation> attenuation = nullptr;
   bool elastic1D = false;
   if (attBuilder) {
     // 1D or 3D
-    eigen::DMatXN QKp = getElemental("QKAPPA");
-    eigen::DMatXN QMu = getElemental("QMU");
-    elastic1D = op1D_3D::regularize1D<eigen::DMatXN>(
+    axisem3d::eigen::DMatXN QKp = getElemental("QKAPPA");
+    axisem3d::eigen::DMatXN QMu = getElemental("QMU");
+    elastic1D = op1D_3D::regularize1D<axisem3d::eigen::DMatXN>(
         {ref(A), ref(C), ref(F), ref(L), ref(N), ref(QKp), ref(QMu)});
 
     // build attenuation
-    eigen::DMatXN kp = (A * 4. + C + F * 4. - N * 4.) / 9.;
-    eigen::DMatXN mu = (A + C - F * 2. + L * 6. + N * 5.) / 15.;
+    axisem3d::eigen::DMatXN kp = (A * 4. + C + F * 4. - N * 4.) / 9.;
+    axisem3d::eigen::DMatXN mu = (A + C - F * 2. + L * 6. + N * 5.) / 15.;
     A -= (kp + 4. / 3. * mu);
     C -= (kp + 4. / 3. * mu);
     F -= (kp - 2. / 3. * mu);
@@ -594,7 +599,8 @@ Material::createTISO(
     N += mu;
   } else {
     // 1D or 3D
-    elastic1D = op1D_3D::regularize1D<eigen::DMatXN>({ref(A), ref(C), ref(F), ref(L), ref(N)});
+    elastic1D =
+        op1D_3D::regularize1D<axisem3d::eigen::DMatXN>({ref(A), ref(C), ref(F), ref(L), ref(N)});
   }
 
   // elastic
@@ -608,18 +614,18 @@ Material::createTISO(
 
 // isotropic
 std::unique_ptr<Elastic>
-Material::createIsotropic(
-    const std::unique_ptr<const AttBuilder>& attBuilder, const eigen::DRow4& weightsCG4) const {
+Material::createIsotropic(const std::unique_ptr<const AttBuilder>& attBuilder,
+    const axisem3d::eigen::DRow4& weightsCG4) const {
   using op1D_3D::toPP;
   using std::ref;
 
   // rho, vp, vs
-  const eigen::DMatXN& rho = getElemental("RHO");
-  const eigen::DMatXN& vp = getElemental("VP");
-  const eigen::DMatXN& vs = getElemental("VS");
+  const axisem3d::eigen::DMatXN& rho = getElemental("RHO");
+  const axisem3d::eigen::DMatXN& vp = getElemental("VP");
+  const axisem3d::eigen::DMatXN& vs = getElemental("VS");
 
   // lambda, mu
-  eigen::DMatXN lambda, mu;
+  axisem3d::eigen::DMatXN lambda, mu;
   op1D_3D::times(rho, vp.array().square().matrix(), lambda);
   op1D_3D::times(rho, vs.array().square().matrix(), mu);
   op1D_3D::addTo(-2. * mu, lambda);
@@ -629,17 +635,18 @@ Material::createIsotropic(
   bool elastic1D = false;
   if (attBuilder) {
     // 1D or 3D
-    eigen::DMatXN QKp = getElemental("QKAPPA");
-    eigen::DMatXN QMu = getElemental("QMU");
-    elastic1D = op1D_3D::regularize1D<eigen::DMatXN>({ref(lambda), ref(mu), ref(QKp), ref(QMu)});
+    axisem3d::eigen::DMatXN QKp = getElemental("QKAPPA");
+    axisem3d::eigen::DMatXN QMu = getElemental("QMU");
+    elastic1D =
+        op1D_3D::regularize1D<axisem3d::eigen::DMatXN>({ref(lambda), ref(mu), ref(QKp), ref(QMu)});
 
     // build attenuation
-    eigen::DMatXN kp = lambda + (2. / 3.) * mu;
+    axisem3d::eigen::DMatXN kp = lambda + (2. / 3.) * mu;
     attenuation = attBuilder->createAttenuation(QKp, QMu, kp, mu, weightsCG4, elastic1D);
     lambda = kp - (2. / 3.) * mu;
   } else {
     // 1D or 3D
-    elastic1D = op1D_3D::regularize1D<eigen::DMatXN>({ref(lambda), ref(mu)});
+    elastic1D = op1D_3D::regularize1D<axisem3d::eigen::DMatXN>({ref(lambda), ref(mu)});
   }
 
   // elastic

--- a/src/preloop/se_model/quad/physical/Material.hpp
+++ b/src/preloop/se_model/quad/physical/Material.hpp
@@ -31,14 +31,14 @@ class Material {
   public:
   ////////////////////////// input //////////////////////////
   // constructor
-  Material(const ExodusMesh& exodusMesh, const eigen::DMat24& nodalSZ, bool axial);
+  Material(const ExodusMesh& exodusMesh, const axisem3d::eigen::DMat24& nodalSZ, bool axial);
 
   // add a 3D property
   void
   addProperty3D(const std::string& propKey,
       const Volumetric3D::ReferenceKind& refKind,
-      const eigen::arN_IColX& inScope,
-      const eigen::arN_DColX& propValue);
+      const axisem3d::eigen::arN_IColX& inScope,
+      const axisem3d::eigen::arN_DColX& propValue);
 
   // finished 3D properties
   void
@@ -46,17 +46,20 @@ class Material {
 
   ////////////////////////// output //////////////////////////
   // get maximum velocity for dt
-  eigen::DMatXN
+  axisem3d::eigen::DMatXN
   getMaxVelocity() const;
 
   // get rho, vp, vs for Clayton
   void
-  getPointwiseRhoVpVs(eigen::arN_DColX& rho, eigen::arN_DColX& vp, eigen::arN_DColX& vs) const;
+  getPointwiseRhoVpVs(axisem3d::eigen::arN_DColX& rho,
+      axisem3d::eigen::arN_DColX& vp,
+      axisem3d::eigen::arN_DColX& vs) const;
 
   // get mass for GLL-point setup
-  eigen::arN_DColX
-  getMass(
-      const eigen::DRowN& integralFactor, const eigen::arN_DColX& jacobianPRT, bool fluid) const;
+  axisem3d::eigen::arN_DColX
+  getMass(const axisem3d::eigen::DRowN& integralFactor,
+      const axisem3d::eigen::arN_DColX& jacobianPRT,
+      bool fluid) const;
 
   // create Acoustic
   std::unique_ptr<Acoustic>
@@ -64,35 +67,35 @@ class Material {
 
   // create Elastic
   std::unique_ptr<Elastic>
-  createElastic(
-      const std::unique_ptr<const AttBuilder>& attBuilder, const eigen::DRow4& weightsCG4) const;
+  createElastic(const std::unique_ptr<const AttBuilder>& attBuilder,
+      const axisem3d::eigen::DRow4& weightsCG4) const;
 
   private:
   // anisotropic
   std::unique_ptr<Elastic>
-  createAnisotropic(
-      const std::unique_ptr<const AttBuilder>& attBuilder, const eigen::DRow4& weightsCG4) const;
+  createAnisotropic(const std::unique_ptr<const AttBuilder>& attBuilder,
+      const axisem3d::eigen::DRow4& weightsCG4) const;
 
   // transversely isotropic
   std::unique_ptr<Elastic>
-  createTISO(
-      const std::unique_ptr<const AttBuilder>& attBuilder, const eigen::DRow4& weightsCG4) const;
+  createTISO(const std::unique_ptr<const AttBuilder>& attBuilder,
+      const axisem3d::eigen::DRow4& weightsCG4) const;
 
   // isotropic
   std::unique_ptr<Elastic>
-  createIsotropic(
-      const std::unique_ptr<const AttBuilder>& attBuilder, const eigen::DRow4& weightsCG4) const;
+  createIsotropic(const std::unique_ptr<const AttBuilder>& attBuilder,
+      const axisem3d::eigen::DRow4& weightsCG4) const;
 
   ////////////////////// property //////////////////////
   private:
   // get property pointwise
-  eigen::arN_DColX
+  axisem3d::eigen::arN_DColX
   getPointwise(const std::string& key) const {
     return getProperty(key).getPointwise();
   }
 
   // get property elemental
-  eigen::DMatXN
+  axisem3d::eigen::DMatXN
   getElemental(const std::string& key) const {
     return getProperty(key).getElemental();
   }
@@ -159,8 +162,8 @@ class Material {
     mProperties.insert({"VSV", mProperties.at("VS")});
     mProperties.insert({"VSH", mProperties.at("VS")});
     // eta
-    mProperties.insert(
-        {"ETA", NodalPhysicalProperty(eigen::DRow4::Ones(), mProperties.at("RHO").axial())});
+    mProperties.insert({"ETA",
+        NodalPhysicalProperty(axisem3d::eigen::DRow4::Ones(), mProperties.at("RHO").axial())});
     // erase vp, vs
     mProperties.erase("VP");
     mProperties.erase("VS");
@@ -183,7 +186,7 @@ class Material {
     const NodalPhysicalProperty& N = rho * vsh.pow(2.);
     const NodalPhysicalProperty& F = eta * (A - L * 2.);
     const NodalPhysicalProperty& zero =
-        NodalPhysicalProperty(eigen::DRow4::Zero(), mProperties.at("RHO").axial());
+        NodalPhysicalProperty(axisem3d::eigen::DRow4::Zero(), mProperties.at("RHO").axial());
     // Cijkl
     // non-zero
     mProperties.insert({"C11", A});

--- a/src/preloop/se_model/quad/physical/OceanLoad.hpp
+++ b/src/preloop/se_model/quad/physical/OceanLoad.hpp
@@ -18,12 +18,12 @@ class OceanLoad {
   public:
   // add sum(rho * depth)
   void
-  addSumRhoDepth(const eigen::arP_DColX& sumRD) {
+  addSumRhoDepth(const axisem3d::eigen::arP_DColX& sumRD) {
     mSumRhoDepth.addGLL(sumRD);
   }
 
   // get pointwise
-  eigen::arP_DColX
+  axisem3d::eigen::arP_DColX
   getPointwise() const {
     return mSumRhoDepth.getPointwise();
   }

--- a/src/preloop/se_model/quad/physical/PhysicalProperty.hpp
+++ b/src/preloop/se_model/quad/physical/PhysicalProperty.hpp
@@ -8,9 +8,9 @@
 // -----------------------------------------------------------------------------
 
 //  physical property on element
-//  NOTE: 1) data are stored pointwise by std::array<eigen::DColX, nPEM>
+//  NOTE: 1) data are stored pointwise by std::array<axisem3d::eigen::DColX, nPEM>
 //        2) data can only be empty (rows=0), 1D (rows=1) or 3D (rows=nr)
-//        3) computed elemental data are stored in eigen::DMatXN,
+//        3) computed elemental data are stored in axisem3d::eigen::DMatXN,
 //           either 1D (row=1) or 3D (row=nr_max)
 //        4) getPointwise() and getElemental() return 1D zero if data is empty
 
@@ -22,13 +22,13 @@
 // property without nodal
 template <int M> class PhysicalProperty {
   protected:
-  typedef std::array<eigen::DColX, M> arM_DColX;
+  typedef std::array<axisem3d::eigen::DColX, M> arM_DColX;
   typedef Eigen::Matrix<double, Eigen::Dynamic, M> DMatXM;
 
   public:
   // constructor
   PhysicalProperty() : mGLL() {
-    mGLL.fill(eigen::DColX(0));
+    mGLL.fill(axisem3d::eigen::DColX(0));
   }
 
   // constructor
@@ -55,7 +55,7 @@ template <int M> class PhysicalProperty {
     } else {
       // return zero array with 1D size
       arM_DColX zero;
-      zero.fill(eigen::DColX::Zero(1));
+      zero.fill(axisem3d::eigen::DColX::Zero(1));
       return zero;
     }
   }
@@ -152,7 +152,7 @@ template <int M> class PhysicalProperty {
 class NodalPhysicalProperty : public PhysicalProperty<spectral::nPEM> {
   public:
   // constructor with nodal
-  NodalPhysicalProperty(const eigen::DRow4& nodal, bool axial) :
+  NodalPhysicalProperty(const axisem3d::eigen::DRow4& nodal, bool axial) :
       PhysicalProperty<spectral::nPEM>(), mNodal(nodal), mAxial(axial) {
     // nothing
   }
@@ -166,16 +166,16 @@ class NodalPhysicalProperty : public PhysicalProperty<spectral::nPEM> {
   // get pointwise from nodal
   arM_DColX
   getPointwiseNodal() const {
-    const eigen::DRowN& mat = spectrals::interpolateGLL(mNodal, mAxial);
-    eigen::arN_DColX ar;
+    const axisem3d::eigen::DRowN& mat = spectrals::interpolateGLL(mNodal, mAxial);
+    axisem3d::eigen::arN_DColX ar;
     for (int ipnt = 0; ipnt < spectral::nPEM; ipnt++) {
-      ar[ipnt] = (eigen::DColX(1) << mat(ipnt)).finished();
+      ar[ipnt] = (axisem3d::eigen::DColX(1) << mat(ipnt)).finished();
     }
     return ar;
   }
 
   // get elemental from nodal
-  eigen::DMatXN
+  axisem3d::eigen::DMatXN
   getElementalNodal() const {
     return spectrals::interpolateGLL(mNodal, mAxial);
   }
@@ -193,7 +193,7 @@ class NodalPhysicalProperty : public PhysicalProperty<spectral::nPEM> {
   }
 
   // get elemental
-  eigen::DMatXN
+  axisem3d::eigen::DMatXN
   getElemental() const {
     if (*this) {
       // preferentially use GLL
@@ -205,7 +205,7 @@ class NodalPhysicalProperty : public PhysicalProperty<spectral::nPEM> {
   }
 
   // get nodal
-  const eigen::DRow4
+  const axisem3d::eigen::DRow4
   getNodalData() const {
     return mNodal;
   }
@@ -264,8 +264,8 @@ class NodalPhysicalProperty : public PhysicalProperty<spectral::nPEM> {
     result.mNodal += other.mNodal;
     // GLL: no need to compute GLL if both are nodal only
     if (*this || other) {
-      const eigen::arN_DColX& gllThis = this->getPointwise();
-      const eigen::arN_DColX& gllOther = other.getPointwise();
+      const axisem3d::eigen::arN_DColX& gllThis = this->getPointwise();
+      const axisem3d::eigen::arN_DColX& gllOther = other.getPointwise();
       for (int ipnt = 0; ipnt < spectral::nPEM; ipnt++) {
         result.mGLL[ipnt] = gllThis[ipnt];
         op1D_3D::addTo(gllOther[ipnt], result.mGLL[ipnt]);
@@ -289,8 +289,8 @@ class NodalPhysicalProperty : public PhysicalProperty<spectral::nPEM> {
     result.mNodal.array() *= other.mNodal.array();
     // GLL: no need to compute GLL if both are nodal only
     if (*this || other) {
-      const eigen::arN_DColX& gllThis = this->getPointwise();
-      const eigen::arN_DColX& gllOther = other.getPointwise();
+      const axisem3d::eigen::arN_DColX& gllThis = this->getPointwise();
+      const axisem3d::eigen::arN_DColX& gllOther = other.getPointwise();
       for (int ipnt = 0; ipnt < spectral::nPEM; ipnt++) {
         op1D_3D::times(gllThis[ipnt], gllOther[ipnt], result.mGLL[ipnt]);
       }
@@ -309,7 +309,7 @@ class NodalPhysicalProperty : public PhysicalProperty<spectral::nPEM> {
   bool mAxial;
 
   // nodal
-  eigen::DRow4 mNodal;
+  axisem3d::eigen::DRow4 mNodal;
 };
 
 #endif /* PhysicalProperty_hpp */

--- a/src/preloop/se_model/quad/physical/Undulation.cpp
+++ b/src/preloop/se_model/quad/physical/Undulation.cpp
@@ -46,13 +46,13 @@ Undulation::finished3D(const Quad& myQuad) {
 
   ////////////////////// compute gradient //////////////////////
   // step 1: FFT
-  const eigen::DMatXN& dz = getElemental();
+  const axisem3d::eigen::DMatXN& dz = getElemental();
   int nr = (int)dz.rows();
   sFFT_N1.computeR2C(dz, sDeltaZ_Fourier, nr);
 
   // step 2: gradient
-  static eigen::DMat2N sz;
-  static eigen::DMatPP_RM ifPP;
+  static axisem3d::eigen::DMat2N sz;
+  static axisem3d::eigen::DMatPP_RM ifPP;
   const auto& grad = myQuad.createGradient<double>(sz, ifPP);
   grad->checkCompatibility(nr);
   grad->computeGrad3(sDeltaZ_Fourier, sDeltaZ_SPZ_Fourier, nr / 2 + 1);
@@ -64,12 +64,12 @@ Undulation::finished3D(const Quad& myQuad) {
   // step 4: rotate
   if (!geodesy::isCartesian()) {
     // theta
-    const eigen::DMat2N& rt = geodesy::sz2rtheta(sz, false);
-    const eigen::DRowN& cost = rt.array().row(1).cos();
-    const eigen::DRowN& sint = rt.array().row(1).sin();
+    const axisem3d::eigen::DMat2N& rt = geodesy::sz2rtheta(sz, false);
+    const axisem3d::eigen::DRowN& cost = rt.array().row(1).cos();
+    const axisem3d::eigen::DRowN& sint = rt.array().row(1).sin();
     // s, z
-    const eigen::DMatXN& dZds = mDeltaZ_RTZ.block(0, nPEM * 0, nr, nPEM);
-    const eigen::DMatXN& dZdz = mDeltaZ_RTZ.block(0, nPEM * 2, nr, nPEM);
+    const axisem3d::eigen::DMatXN& dZds = mDeltaZ_RTZ.block(0, nPEM * 0, nr, nPEM);
+    const axisem3d::eigen::DMatXN& dZdz = mDeltaZ_RTZ.block(0, nPEM * 2, nr, nPEM);
     // s, z -> R, Z
     mDeltaZ_RTZ.block(0, nPEM * 0, nr, nPEM) =
         dZds.array() * cost.array().replicate(nr, 1) - dZdz.array() * sint.array().replicate(nr, 1);
@@ -79,16 +79,16 @@ Undulation::finished3D(const Quad& myQuad) {
 }
 
 // get Jacobian for mass
-eigen::arN_DColX
-Undulation::getMassJacobian(const eigen::DMat2N& sz) const {
+axisem3d::eigen::arN_DColX
+Undulation::getMassJacobian(const axisem3d::eigen::DMat2N& sz) const {
   // no undulation
   if (!mDeltaZ) {
-    return eigen::arN_DColX();
+    return axisem3d::eigen::arN_DColX();
   }
 
   // allocate dZdZ with the same size as dZ
-  const eigen::arN_DColX& dZ = getPointwise();
-  eigen::arN_DColX dZdZ = dZ;
+  const axisem3d::eigen::arN_DColX& dZ = getPointwise();
+  axisem3d::eigen::arN_DColX dZdZ = dZ;
   int maxNr = (int)mDeltaZ_RTZ.rows();
   for (int ipnt = 0; ipnt < nPEM; ipnt++) {
     int nr = (int)dZdZ[ipnt].rows();
@@ -100,12 +100,12 @@ Undulation::getMassJacobian(const eigen::DMat2N& sz) const {
 
   // compute Jacobian
   // based on eq.(6) in Leng et al., 2019
-  eigen::arN_DColX J;
+  axisem3d::eigen::arN_DColX J;
   for (int ipnt = 0; ipnt < nPEM; ipnt++) {
-    const eigen::DColX& J3 = 1. + dZdZ[ipnt].array();
-    eigen::DColX J0;
+    const axisem3d::eigen::DColX& J3 = 1. + dZdZ[ipnt].array();
+    axisem3d::eigen::DColX J0;
     if (geodesy::isCartesian()) {
-      J0 = eigen::DColX::Ones(J3.rows());
+      J0 = axisem3d::eigen::DColX::Ones(J3.rows());
     } else {
       double Z = sz.col(ipnt).norm();
       J0 = (Z > numerical::dEpsilon) ? (1. + dZ[ipnt].array() / Z) : J3;
@@ -121,7 +121,7 @@ Undulation::getMassJacobian(const eigen::DMat2N& sz) const {
 
 // create PRT
 std::unique_ptr<const PRT>
-Undulation::createPRT(const eigen::DMat2N& sz) const {
+Undulation::createPRT(const axisem3d::eigen::DMat2N& sz) const {
   // no undulation
   if (!mDeltaZ) {
     return nullptr;
@@ -130,25 +130,25 @@ Undulation::createPRT(const eigen::DMat2N& sz) const {
   // compute Jacobian
   // based on eq.(6) in Leng et al., 2019
   int nr = (int)mDeltaZ_RTZ.rows();
-  const eigen::DMatXN& J1 = mDeltaZ_RTZ.block(0, nPEM * 0, nr, nPEM);
-  const eigen::DMatXN& J2 = mDeltaZ_RTZ.block(0, nPEM * 1, nr, nPEM);
-  const eigen::DMatXN& J3 = 1. + mDeltaZ_RTZ.block(0, nPEM * 2, nr, nPEM).array();
-  eigen::DMatXN J0;
+  const axisem3d::eigen::DMatXN& J1 = mDeltaZ_RTZ.block(0, nPEM * 0, nr, nPEM);
+  const axisem3d::eigen::DMatXN& J2 = mDeltaZ_RTZ.block(0, nPEM * 1, nr, nPEM);
+  const axisem3d::eigen::DMatXN& J3 = 1. + mDeltaZ_RTZ.block(0, nPEM * 2, nr, nPEM).array();
+  axisem3d::eigen::DMatXN J0;
   if (geodesy::isCartesian()) {
-    J0 = eigen::DMatXN::Ones(nr, nPEM);
+    J0 = axisem3d::eigen::DMatXN::Ones(nr, nPEM);
   } else {
-    const eigen::DMatXN& dZ = getElemental();
-    const eigen::DMatXN& Z = sz.colwise().norm().replicate(nr, 1);
+    const axisem3d::eigen::DMatXN& dZ = getElemental();
+    const axisem3d::eigen::DMatXN& Z = sz.colwise().norm().replicate(nr, 1);
     J0 = (Z.array() > numerical::dEpsilon).select(1. + dZ.array() / Z.array(), J3);
   }
 
   // compute inverse Jacobian
   // based on eq.(13) in Leng et al., 2019
-  const eigen::DMatXN& X0 = J0.cwiseInverse();
-  const eigen::DMatXN& X1 = -J1.cwiseQuotient((J0.cwiseProduct(J3)));
-  const eigen::DMatXN& X2 = -J2.cwiseQuotient((J0.cwiseProduct(J3)));
-  const eigen::DMatXN& X3 = J3.cwiseInverse();
-  const eigen::DMatXN& XJ = J0.array().square() * J3.array();
+  const axisem3d::eigen::DMatXN& X0 = J0.cwiseInverse();
+  const axisem3d::eigen::DMatXN& X1 = -J1.cwiseQuotient((J0.cwiseProduct(J3)));
+  const axisem3d::eigen::DMatXN& X2 = -J2.cwiseQuotient((J0.cwiseProduct(J3)));
+  const axisem3d::eigen::DMatXN& X3 = J3.cwiseInverse();
+  const axisem3d::eigen::DMatXN& XJ = J0.array().square() * J3.array();
   if (XJ.minCoeff() < numerical::dEpsilon) {
     throw std::runtime_error("Undulation::createPRT || "
                              "Negative Jacobian or distorted element occurred.");
@@ -167,48 +167,49 @@ Undulation::createPRT(const eigen::DMat2N& sz) const {
 }
 
 // compute 3D normal at a point
-eigen::DMatX3
-Undulation::computeNormal3D(const eigen::DCol2& n1D, const eigen::DMat2N& sz, int ipnt) const {
+axisem3d::eigen::DMatX3
+Undulation::computeNormal3D(
+    const axisem3d::eigen::DCol2& n1D, const axisem3d::eigen::DMat2N& sz, int ipnt) const {
   // no undulation
   if (!mDeltaZ) {
-    return (eigen::DMatX3(1, 3) << n1D(0), 0., n1D(1)).finished();
+    return (axisem3d::eigen::DMatX3(1, 3) << n1D(0), 0., n1D(1)).finished();
   }
 
   // dZ
-  const eigen::arN_DColX& dZ = getPointwise();
+  const axisem3d::eigen::arN_DColX& dZ = getPointwise();
 
   // extract gradient of dZ
   int nr = (int)dZ[ipnt].rows();
   int maxNr = (int)mDeltaZ_RTZ.rows();
-  eigen::DColX dZdR(nr), dZdT(nr), dZdZ(nr);
+  axisem3d::eigen::DColX dZdR(nr), dZdT(nr), dZdZ(nr);
   PhysicalProperty<nPEM>::linInterpPhi(mDeltaZ_RTZ, dZdR, nPEM * 0 + ipnt, 0, maxNr, nr);
   PhysicalProperty<nPEM>::linInterpPhi(mDeltaZ_RTZ, dZdT, nPEM * 1 + ipnt, 0, maxNr, nr);
   PhysicalProperty<nPEM>::linInterpPhi(mDeltaZ_RTZ, dZdZ, nPEM * 2 + ipnt, 0, maxNr, nr);
 
   // compute Jacobian
   // based on eq.(6) in Leng et al., 2019
-  const eigen::DColX& J1 = dZdR;
-  const eigen::DColX& J2 = dZdT;
-  const eigen::DColX& J3 = 1. + dZdZ.array();
-  eigen::DColX J0;
+  const axisem3d::eigen::DColX& J1 = dZdR;
+  const axisem3d::eigen::DColX& J2 = dZdT;
+  const axisem3d::eigen::DColX& J3 = 1. + dZdZ.array();
+  axisem3d::eigen::DColX J0;
   if (geodesy::isCartesian()) {
-    J0 = eigen::DColX::Ones(J3.rows());
+    J0 = axisem3d::eigen::DColX::Ones(J3.rows());
   } else {
     double Z = sz.col(ipnt).norm();
     J0 = (Z > numerical::dEpsilon) ? (1. + dZ[ipnt].array() / Z) : J3;
   }
 
   // K = J^-T |J|
-  const eigen::DColX& K0 = J3.cwiseProduct(J0);
-  const eigen::DColX& K1 = -J1.cwiseProduct(J0);
-  const eigen::DColX& K2 = -J2.cwiseProduct(J0);
-  const eigen::DColX& K3 = J0.cwiseProduct(J0);
+  const axisem3d::eigen::DColX& K0 = J3.cwiseProduct(J0);
+  const axisem3d::eigen::DColX& K1 = -J1.cwiseProduct(J0);
+  const axisem3d::eigen::DColX& K2 = -J2.cwiseProduct(J0);
+  const axisem3d::eigen::DColX& K3 = J0.cwiseProduct(J0);
 
   // rotate n1D to RTZ
   double sint = 0., cost = 0.;
-  eigen::DCol2 n1D_RZ = n1D;
+  axisem3d::eigen::DCol2 n1D_RZ = n1D;
   if (!geodesy::isCartesian()) {
-    const eigen::DCol2& rt = geodesy::sz2rtheta(sz.col(ipnt).eval(), false);
+    const axisem3d::eigen::DCol2& rt = geodesy::sz2rtheta(sz.col(ipnt).eval(), false);
     sint = sin(rt(1));
     cost = cos(rt(1));
     n1D_RZ(0) = n1D(0) * cost - n1D(1) * sint;
@@ -217,14 +218,14 @@ Undulation::computeNormal3D(const eigen::DCol2& n1D, const eigen::DMat2N& sz, in
 
   // K * n
   // based on eq.(A4) in Leng et al., 2019
-  eigen::DMatX3 n3D_RTZ(nr, 3);
+  axisem3d::eigen::DMatX3 n3D_RTZ(nr, 3);
   n3D_RTZ.col(0) = K1 * n1D_RZ(1) + K0 * n1D_RZ(0);
   n3D_RTZ.col(1) = K2 * n1D_RZ(1);
   n3D_RTZ.col(2) = K3 * n1D_RZ(1);
 
   // rotate back to SPZ
   if (!geodesy::isCartesian()) {
-    eigen::DMatX3 n3D_SPZ(nr, 3);
+    axisem3d::eigen::DMatX3 n3D_SPZ(nr, 3);
     n3D_SPZ.col(0) = n3D_RTZ.col(0) * cost + n3D_RTZ.col(2) * sint;
     n3D_SPZ.col(2) = n3D_RTZ.col(2) * cost - n3D_RTZ.col(0) * sint;
     n3D_SPZ.col(1) = n3D_RTZ.col(1);

--- a/src/preloop/se_model/quad/physical/Undulation.hpp
+++ b/src/preloop/se_model/quad/physical/Undulation.hpp
@@ -19,7 +19,7 @@
 // gradient
 #include "SolverFFTW.hpp"
 class Quad;
-namespace eigen {
+namespace axisem3d::eigen {
   using numerical::ComplexD;
   using spectral::nPED;
   using spectral::nPEM;
@@ -27,7 +27,7 @@ namespace eigen {
   typedef std::vector<std::array<ZMatPP_RM, 1>> vec_ar1_ZMatPP_RM;
   typedef std::vector<std::array<ZMatPP_RM, 3>> vec_ar3_ZMatPP_RM;
   typedef Eigen::Matrix<double, Eigen::Dynamic, nPEM * 3> DMatXN3;
-} // namespace eigen
+} // namespace axisem3d::eigen
 
 // release
 #include "PRT.hpp"
@@ -36,18 +36,18 @@ class Undulation {
   public:
   // add undulation
   void
-  addUndulation(const eigen::arN_DColX& und) {
+  addUndulation(const axisem3d::eigen::arN_DColX& und) {
     mDeltaZ.addGLL(und);
   }
 
   // get elemental
-  eigen::DMatXN
+  axisem3d::eigen::DMatXN
   getElemental() const {
     return mDeltaZ.getElemental();
   }
 
   // get pointwise
-  eigen::arN_DColX
+  axisem3d::eigen::arN_DColX
   getPointwise() const {
     return mDeltaZ.getPointwise();
   }
@@ -61,16 +61,17 @@ class Undulation {
   finished3D(const Quad& myQuad);
 
   // get Jacobian for mass
-  eigen::arN_DColX
-  getMassJacobian(const eigen::DMat2N& sz) const;
+  axisem3d::eigen::arN_DColX
+  getMassJacobian(const axisem3d::eigen::DMat2N& sz) const;
 
   // create PRT
   std::unique_ptr<const PRT>
-  createPRT(const eigen::DMat2N& sz) const;
+  createPRT(const axisem3d::eigen::DMat2N& sz) const;
 
   // compute 3D normal at a point
-  eigen::DMatX3
-  computeNormal3D(const eigen::DCol2& n1D, const eigen::DMat2N& sz, int ipnt) const;
+  axisem3d::eigen::DMatX3
+  computeNormal3D(
+      const axisem3d::eigen::DCol2& n1D, const axisem3d::eigen::DMat2N& sz, int ipnt) const;
 
   ///////////////////////// data /////////////////////////
   private:
@@ -78,7 +79,7 @@ class Undulation {
   PhysicalProperty<spectral::nPEM> mDeltaZ;
 
   // gradient of delta Z
-  eigen::DMatXN3 mDeltaZ_RTZ;
+  axisem3d::eigen::DMatXN3 mDeltaZ_RTZ;
 
   ///////////////////////// static /////////////////////////
   public:
@@ -90,8 +91,8 @@ class Undulation {
   // static fft variables
   inline static SolverFFTW<double, spectral::nPEM> sFFT_N1;
   inline static SolverFFTW<double, spectral::nPEM * 3> sFFT_N3;
-  inline static eigen::vec_ar1_ZMatPP_RM sDeltaZ_Fourier;
-  inline static eigen::vec_ar3_ZMatPP_RM sDeltaZ_SPZ_Fourier;
+  inline static axisem3d::eigen::vec_ar1_ZMatPP_RM sDeltaZ_Fourier;
+  inline static axisem3d::eigen::vec_ar3_ZMatPP_RM sDeltaZ_SPZ_Fourier;
 };
 
 #endif /* Undulation_hpp */

--- a/src/preloop/se_model/quad/spectrals.hpp
+++ b/src/preloop/se_model/quad/spectrals.hpp
@@ -749,27 +749,33 @@ namespace spectrals {
   ////////////////// global constants //////////////////
   // point positions
   // GLL
-  const eigen::DColP gPositionsGLL = Eigen::Map<const eigen::DColP>(internal::pGLL.data());
+  const axisem3d::eigen::DColP gPositionsGLL =
+      Eigen::Map<const axisem3d::eigen::DColP>(internal::pGLL.data());
   // GLJ
-  const eigen::DColP gPositionsGLJ = Eigen::Map<const eigen::DColP>(internal::pGLJ.data());
+  const axisem3d::eigen::DColP gPositionsGLJ =
+      Eigen::Map<const axisem3d::eigen::DColP>(internal::pGLJ.data());
 
   // weights
   // GLL
-  const eigen::DColP gWeightsGLL = Eigen::Map<const eigen::DColP>(internal::wGLL.data());
+  const axisem3d::eigen::DColP gWeightsGLL =
+      Eigen::Map<const axisem3d::eigen::DColP>(internal::wGLL.data());
   // GLJ
-  const eigen::DColP gWeightsGLJ = Eigen::Map<const eigen::DColP>(internal::wGLJ.data());
+  const axisem3d::eigen::DColP gWeightsGLJ =
+      Eigen::Map<const axisem3d::eigen::DColP>(internal::wGLJ.data());
 
   // G matrix
   // GLL
-  const eigen::DMatPP_RM gGMatrixGLL = Eigen::Map<const eigen::DMatPP_RM>(internal::gGLL.data());
+  const axisem3d::eigen::DMatPP_RM gGMatrixGLL =
+      Eigen::Map<const axisem3d::eigen::DMatPP_RM>(internal::gGLL.data());
   // GLJ
-  const eigen::DMatPP_RM gGMatrixGLJ = Eigen::Map<const eigen::DMatPP_RM>(internal::gGLJ.data());
+  const axisem3d::eigen::DMatPP_RM gGMatrixGLJ =
+      Eigen::Map<const axisem3d::eigen::DMatPP_RM>(internal::gGLJ.data());
 
   ///////////////////////////// methods /////////////////////////////
   // xieta on element
-  inline const eigen::DMat2N&
+  inline const axisem3d::eigen::DMat2N&
   getXiEtaElement(bool axial) {
-    static eigen::DMat2N xietaAX, xietaNA;
+    static axisem3d::eigen::DMat2N xietaAX, xietaNA;
     static bool formed = false;
     if (!formed) {
       for (int ipol = 0; ipol < spectral::nPED; ipol++) {
@@ -789,14 +795,14 @@ namespace spectrals {
   }
 
   // weights on element
-  inline eigen::DRowN
+  inline axisem3d::eigen::DRowN
   getWeightsElement(bool axial) {
     if (axial) {
-      eigen::DMatPP_RM wmat = (gWeightsGLJ * gWeightsGLL.transpose());
-      return Eigen::Map<eigen::DRowN>(wmat.data());
+      axisem3d::eigen::DMatPP_RM wmat = (gWeightsGLJ * gWeightsGLL.transpose());
+      return Eigen::Map<axisem3d::eigen::DRowN>(wmat.data());
     } else {
-      eigen::DMatPP_RM wmat = (gWeightsGLL * gWeightsGLL.transpose());
-      return Eigen::Map<eigen::DRowN>(wmat.data());
+      axisem3d::eigen::DMatPP_RM wmat = (gWeightsGLL * gWeightsGLL.transpose());
+      return Eigen::Map<axisem3d::eigen::DRowN>(wmat.data());
     }
   }
 
@@ -810,7 +816,7 @@ namespace spectrals {
     if (!formed) {
       {
         // axial
-        const eigen::DMat2N& xieta = getXiEtaElement(true);
+        const axisem3d::eigen::DMat2N& xieta = getXiEtaElement(true);
         const auto& xip = 1. + xieta.row(0).array();
         const auto& xim = 1. - xieta.row(0).array();
         const auto& etp = 1. + xieta.row(1).array();
@@ -823,7 +829,7 @@ namespace spectrals {
       }
       {
         // non-axial
-        const eigen::DMat2N& xieta = getXiEtaElement(false);
+        const axisem3d::eigen::DMat2N& xieta = getXiEtaElement(false);
         const auto& xip = 1. + xieta.row(0).array();
         const auto& xim = 1. - xieta.row(0).array();
         const auto& etp = 1. + xieta.row(1).array();

--- a/src/preloop/source/Mechanism.cpp
+++ b/src/preloop/source/Mechanism.cpp
@@ -35,16 +35,16 @@ Mechanism::buildInparam(int sindex, const std::string& sourceName) {
 
   // data
   const std::vector<double>& vec = gm.getVector<double>(root + ":data");
-  eigen::DColX data = Eigen::Map<const eigen::DColX>(vec.data(), vec.size());
+  axisem3d::eigen::DColX data = Eigen::Map<const axisem3d::eigen::DColX>(vec.data(), vec.size());
   data *= gm.get<double>(root + ":unit");
   return std::make_unique<Mechanism>(type, data);
 }
 
 // release element source
 void
-Mechanism::release(const eigen::DMat33& Qzsp,
+Mechanism::release(const axisem3d::eigen::DMat33& Qzsp,
     bool sourceOnAxis,
-    const eigen::DRowN& inplaneFactor,
+    const axisem3d::eigen::DRowN& inplaneFactor,
     double phi,
     const Quad& quad,
     std::unique_ptr<STF>& stf,
@@ -62,12 +62,12 @@ Mechanism::release(const eigen::DMat33& Qzsp,
   std::unique_ptr<const ElementSource> src = nullptr;
   if (mType == SM_Type::FluidPressure) {
     // interpolated data
-    const eigen::DRowN& p = mData(0) * inplaneFactor;
+    const axisem3d::eigen::DRowN& p = mData(0) * inplaneFactor;
     // allocate
     if (sourceOnAxis) {
       nu_1 = std::min(nu_1, 1);
     }
-    eigen::ZMatXN pattern(nu_1, nPEM);
+    axisem3d::eigen::ZMatXN pattern(nu_1, nPEM);
     // non-axial
     if (sourceOnAxis) {
       pattern.setZero();
@@ -90,16 +90,16 @@ Mechanism::release(const eigen::DMat33& Qzsp,
         stf, quad.getFluidElement(), pattern.cast<numerical::ComplexR>());
   } else if (mType == SM_Type::ForceVector) {
     // rotate data
-    const eigen::DColX& fzsp = Qzsp * mData;
+    const axisem3d::eigen::DColX& fzsp = Qzsp * mData;
     // interpolated data
-    const eigen::DRowN& fs = fzsp(1) * inplaneFactor;
-    const eigen::DRowN& fp = fzsp(2) * inplaneFactor;
-    const eigen::DRowN& fz = fzsp(0) * inplaneFactor;
+    const axisem3d::eigen::DRowN& fs = fzsp(1) * inplaneFactor;
+    const axisem3d::eigen::DRowN& fp = fzsp(2) * inplaneFactor;
+    const axisem3d::eigen::DRowN& fz = fzsp(0) * inplaneFactor;
     // allocate
     if (sourceOnAxis) {
       nu_1 = std::min(nu_1, 2);
     }
-    eigen::ZMatXN3 pattern(nu_1, nPEM * 3);
+    axisem3d::eigen::ZMatXN3 pattern(nu_1, nPEM * 3);
     // non-axial
     if (sourceOnAxis) {
       pattern.setZero();
@@ -133,7 +133,7 @@ Mechanism::release(const eigen::DMat33& Qzsp,
         stf, quad.getSolidElement(), pattern.cast<numerical::ComplexR>());
   } else {
     // rotate data
-    static eigen::DMat33 m;
+    static axisem3d::eigen::DMat33 m;
     m(0, 0) = mData(0);
     m(1, 1) = mData(1);
     m(2, 2) = mData(2);
@@ -153,17 +153,17 @@ Mechanism::release(const eigen::DMat33& Qzsp,
     // mzz msz mpz
     // msz mss msp
     // mpz msp mpp
-    const eigen::DRowN& mss = m(1, 1) * inplaneFactor;
-    const eigen::DRowN& mpp = m(2, 2) * inplaneFactor;
-    const eigen::DRowN& mzz = m(0, 0) * inplaneFactor;
-    const eigen::DRowN& mpz = m(0, 2) * inplaneFactor;
-    const eigen::DRowN& msz = m(0, 1) * inplaneFactor;
-    const eigen::DRowN& msp = m(1, 2) * inplaneFactor;
+    const axisem3d::eigen::DRowN& mss = m(1, 1) * inplaneFactor;
+    const axisem3d::eigen::DRowN& mpp = m(2, 2) * inplaneFactor;
+    const axisem3d::eigen::DRowN& mzz = m(0, 0) * inplaneFactor;
+    const axisem3d::eigen::DRowN& mpz = m(0, 2) * inplaneFactor;
+    const axisem3d::eigen::DRowN& msz = m(0, 1) * inplaneFactor;
+    const axisem3d::eigen::DRowN& msp = m(1, 2) * inplaneFactor;
     // allocate
     if (sourceOnAxis) {
       nu_1 = std::min(nu_1, 3);
     }
-    eigen::ZMatXN6 pattern(nu_1, nPEM * 6);
+    axisem3d::eigen::ZMatXN6 pattern(nu_1, nPEM * 6);
     // non-axial
     if (sourceOnAxis) {
       pattern.setZero();

--- a/src/preloop/source/Mechanism.hpp
+++ b/src/preloop/source/Mechanism.hpp
@@ -19,7 +19,7 @@ class Quad;
 class STF;
 class Domain;
 
-namespace eigen {
+namespace axisem3d::eigen {
   using numerical::ComplexD;
   // coords
   typedef Eigen::Matrix<double, 1, 3> DRow3;
@@ -28,7 +28,7 @@ namespace eigen {
   typedef Eigen::Matrix<ComplexD, Eigen::Dynamic, nPEM> ZMatXN;
   typedef Eigen::Matrix<ComplexD, Eigen::Dynamic, nPEM * 3> ZMatXN3;
   typedef Eigen::Matrix<ComplexD, Eigen::Dynamic, nPEM * 6> ZMatXN6;
-} // namespace eigen
+} // namespace axisem3d::eigen
 
 class Mechanism {
   public:
@@ -42,7 +42,7 @@ class Mechanism {
       {SM_Type::MomentTensor, 6}, {SM_Type::ForceVector, 3}, {SM_Type::FluidPressure, 1}};
 
   // constructor
-  Mechanism(const SM_Type& type, const eigen::DColX& data) : mType(type), mData(data) {
+  Mechanism(const SM_Type& type, const axisem3d::eigen::DColX& data) : mType(type), mData(data) {
     // verify
     if (sSM_TypeDim.at(mType) != mData.size()) {
       throw std::runtime_error("Mechanism::Mechanism || "
@@ -65,9 +65,9 @@ class Mechanism {
 
   // release element source
   void
-  release(const eigen::DMat33& Qzsp,
+  release(const axisem3d::eigen::DMat33& Qzsp,
       bool sourceOnAxis,
-      const eigen::DRowN& inplaneFactor,
+      const axisem3d::eigen::DRowN& inplaneFactor,
       double phi,
       const Quad& quad,
       std::unique_ptr<STF>& stf,
@@ -89,7 +89,7 @@ class Mechanism {
   // type
   const SM_Type mType;
   // data
-  const eigen::DColX mData;
+  const axisem3d::eigen::DColX mData;
 
   ////////////////////////////// static //////////////////////////////
   public:

--- a/src/preloop/source/Source.cpp
+++ b/src/preloop/source/Source.cpp
@@ -33,7 +33,7 @@ Source::buildInparam(int sindex) {
   // horizontal
   root += ":location";
   bool axial = false, sourceCentered = false, ellipticity = true;
-  eigen::DRow3 crd = eigen::DRow3::Zero();
+  axisem3d::eigen::DRow3 crd = axisem3d::eigen::DRow3::Zero();
   if (gm.contains(root + ":latitude_longitude")) {
     const std::string& rooth = root + ":latitude_longitude";
     if (gm.get<std::string>(rooth) == "ON_AXIS") {
@@ -97,9 +97,9 @@ Source::buildInparam(int sindex) {
 }
 
 // compute spz
-eigen::DRow3
+axisem3d::eigen::DRow3
 Source::computeSPZ(const SE_Model& sem,
-    const eigen::DRow3& crdIn,
+    const axisem3d::eigen::DRow3& crdIn,
     bool sourceCentered,
     bool xy,
     bool ellipticity,
@@ -109,7 +109,7 @@ Source::computeSPZ(const SE_Model& sem,
     const std::string& errInfo,
     bool enforceOnAxis) {
   // result
-  static eigen::DRow3 crd;
+  static axisem3d::eigen::DRow3 crd;
   crd = crdIn;
 
   // vertical
@@ -152,7 +152,7 @@ Source::computeSPZ(const SE_Model& sem,
       //       Without such "bending", sqrt(s*s+z*z) on the surface
       //       will exceed the outer radius.
       if (geodesy::isCartesian()) {
-        static eigen::DRow3 spzUnbend;
+        static axisem3d::eigen::DRow3 spzUnbend;
         spzUnbend = geodesy::sz2rtheta(crd, true, 0, 2, 2, 0);
         spzUnbend(0) *= spzUnbend(2);
         spzUnbend(1) = crd(1);
@@ -198,9 +198,9 @@ Source::computeSPZ(const SE_Model& sem,
 }
 
 // compute rotation matrix Q from input to (z, s, phi)
-const eigen::DMat33&
-Source::computeQzsp(const eigen::DRow3& spz, bool ellipticity) const {
-  static eigen::DMat33 Qzsp;
+const axisem3d::eigen::DMat33&
+Source::computeQzsp(const axisem3d::eigen::DRow3& spz, bool ellipticity) const {
+  static axisem3d::eigen::DMat33 Qzsp;
   Qzsp.setIdentity();
 
   // axial source needs no rotation
@@ -211,7 +211,7 @@ Source::computeQzsp(const eigen::DRow3& spz, bool ellipticity) const {
   // first rotation: around vertical axis by back azimuth
   if (!mSourceCentered) {
     // compute back azimuth
-    eigen::DRow3 llr = mCrdIn;
+    axisem3d::eigen::DRow3 llr = mCrdIn;
     if (mUseDepth) {
       double R = (mDepthSolid ? geodesy::getOuterSolidRadius() : geodesy::getOuterRadius());
       llr(2) = R - llr(2);
@@ -231,7 +231,7 @@ Source::computeQzsp(const eigen::DRow3& spz, bool ellipticity) const {
     // cos(theta) -sin(theta) 0
     // sin(theta) cos(theta)  0
     // 0          0           1
-    static eigen::DMat33 Qtheta;
+    static axisem3d::eigen::DMat33 Qtheta;
     Qtheta.setIdentity();
     double theta = geodesy::sz2rtheta(spz, true, 0, 2, 2, 0)(0);
     Qtheta(0, 0) = cos(theta);
@@ -318,7 +318,7 @@ Source::release(const SE_Model& sem, Domain& domain, double dt, double& minT0) {
     sources.push_back(source);
 
     // compute spz
-    const eigen::DRow3& spz = computeSPZ(sem,
+    const axisem3d::eigen::DRow3& spz = computeSPZ(sem,
         source->mCrdIn,
         source->mSourceCentered,
         false,
@@ -379,7 +379,7 @@ Source::release(const SE_Model& sem, Domain& domain, double dt, double& minT0) {
 
     // compute spz
     const std::shared_ptr<const Source>& source = sources[sindex];
-    const eigen::DRow3& spz = computeSPZ(sem,
+    const axisem3d::eigen::DRow3& spz = computeSPZ(sem,
         source->mCrdIn,
         source->mSourceCentered,
         false,
@@ -392,7 +392,8 @@ Source::release(const SE_Model& sem, Domain& domain, double dt, double& minT0) {
 
     // inplane interpolation
     int quadTag = sourceIndexQuad.at(sindex);
-    const eigen::DRowN& inplaneFactor = sem.computeInplaneFactor(spz({0, 2}).transpose(), quadTag);
+    const axisem3d::eigen::DRowN& inplaneFactor =
+        sem.computeInplaneFactor(spz({0, 2}).transpose(), quadTag);
 
     // STF
     std::unique_ptr<STF> stf = STF::buildInparam(sindex, source->mName, dt);

--- a/src/preloop/source/Source.hpp
+++ b/src/preloop/source/Source.hpp
@@ -19,10 +19,10 @@ class Mechanism;
 #include <memory>
 
 #include "eigen.hpp"
-namespace eigen {
+namespace axisem3d::eigen {
   typedef Eigen::Matrix<double, 1, 3> DRow3;
   typedef Eigen::Matrix<double, 3, 3> DMat33;
-} // namespace eigen
+} // namespace axisem3d::eigen
 
 class Source {
   public:
@@ -34,7 +34,7 @@ class Source {
       bool useDepth,
       bool depthSolid,
       bool undulatedGeometry,
-      const eigen::DRow3& crdIn) :
+      const axisem3d::eigen::DRow3& crdIn) :
       mName(name), mAxial(axial), mSourceCentered(sourceCentered), mEllipticity(ellipticity),
       mUseDepth(useDepth), mDepthSolid(depthSolid), mUndulatedGeometry(undulatedGeometry),
       mCrdIn(crdIn) {
@@ -48,9 +48,9 @@ class Source {
 
   public:
   // compute spz
-  static eigen::DRow3
+  static axisem3d::eigen::DRow3
   computeSPZ(const SE_Model& sem,
-      const eigen::DRow3& crdIn,
+      const axisem3d::eigen::DRow3& crdIn,
       bool sourceCentered,
       bool xy,
       bool ellipticity,
@@ -62,8 +62,8 @@ class Source {
 
   private:
   // compute rotation matrix Q from input to (z, s, phi)
-  const eigen::DMat33&
-  computeQzsp(const eigen::DRow3& spz, bool ellipticity) const;
+  const axisem3d::eigen::DMat33&
+  computeQzsp(const axisem3d::eigen::DRow3& spz, bool ellipticity) const;
 
   // verbose
   std::string
@@ -83,7 +83,7 @@ class Source {
   const bool mUseDepth;
   const bool mDepthSolid;
   const bool mUndulatedGeometry;
-  const eigen::DRow3 mCrdIn;
+  const axisem3d::eigen::DRow3 mCrdIn;
 };
 
 #endif /* Source_hpp */

--- a/src/shared/data_structure/RTreeND.hpp
+++ b/src/shared/data_structure/RTreeND.hpp
@@ -87,7 +87,7 @@ template <int D, int V, typename T> class RTreeND {
       ctrlVals.resize(ctrlCrds.rows(), V);
       for (int ivar = 0; ivar < V; ivar++) {
         // read to double
-        eigen::DColX ctrlVal;
+        axisem3d::eigen::DColX ctrlVal;
         reader.readMatrixDouble(varInfo[ivar].first, ctrlVal);
         ctrlVal *= varInfo[ivar].second;
         // round

--- a/src/shared/data_structure/StructuredGrid.hpp
+++ b/src/shared/data_structure/StructuredGrid.hpp
@@ -288,10 +288,10 @@ template <int D, typename T> class StructuredGrid {
   }
 
   // get data range
-  eigen::DMatXX
+  axisem3d::eigen::DMatXX
   getDataRange() const {
     // min/max of unique data
-    eigen::DMatXX uniqueMinMax(numUniqueData(), 2);
+    axisem3d::eigen::DMatXX uniqueMinMax(numUniqueData(), 2);
     Eigen::array<Eigen::DenseIndex, 1 + D> start, count;
     start.fill(0);
     count = mGridData.dimensions();
@@ -304,7 +304,7 @@ template <int D, typename T> class StructuredGrid {
     }
 
     // min/max of data
-    eigen::DMatXX dataMinMax(numData(), 2);
+    axisem3d::eigen::DMatXX dataMinMax(numData(), 2);
     for (int ivar = 0; ivar < numData(); ivar++) {
       int index = mDataRankFactor[ivar].first;
       double factor = mDataRankFactor[ivar].second;

--- a/src/shared/eigen/eigen_generic.hpp
+++ b/src/shared/eigen/eigen_generic.hpp
@@ -15,7 +15,7 @@
 #include "eigen.hpp"
 #include "numerical.hpp"
 
-namespace eigen {
+namespace axisem3d::eigen {
   using Eigen::Dynamic;
   using Eigen::RowMajor;
   using numerical::Real;
@@ -75,6 +75,6 @@ namespace eigen {
   typedef Eigen::Matrix<ComplexD, Dynamic, Dynamic, RowMajor> ZMatXX_RM;
   typedef Eigen::Matrix<ComplexD, Dynamic, 1> ZColX;
   typedef Eigen::Matrix<ComplexD, 1, Dynamic> ZRowX;
-} // namespace eigen
+} // namespace axisem3d::eigen
 
 #endif /* eigen_generic_hpp */


### PR DESCRIPTION
This pull request addresses issue  #66 where axisem3d adds to the eigen namespace. Although the Eigen library uses the Eigen namespace (capitalized, so they shouldn't overlap) this pull request changes the namespace to axisem3d::eigen which might be a little more clear.