### PR TITLE
add development-priorities.markdown

### DIFF
--- a/development-priorities.markdown
+++ b/development-priorities.markdown
@@ -1,0 +1,45 @@
+---
+layout: page
+title: Development Priorities
+permalink: /development/
+---
+
+## High Priority Items:
+
+1. #### Fix topography on boundaries
+**Issue**: Topography on boundaries fails in unpredictable ways, especially when there are two boundaries close to each other.  
+**Common error message**: "Negative Jacobian"  
+**Possible solution**: adjust smoothing internal to solver before running time loop (like older versions of AxiSEM3D). 
+This is a common failing mode for solutions across a range of scales and problems (Earth, Moon, Mars) and scales (local to global). Is the highest priority item as of 06-2026.  
+
+2. #### Create a minimum failing example
+**Issue**: In order to make sure that AxiSEM3D stops running whenever it stops outputting NaN results,
+a minimum failing example is needed to reliably produce NaN outputs.
+
+3. #### Output a deformed mesh for checking
+
+4. #### Support for planetary simulations - higher frequency
+
+5. #### Wavefield injection - implement a hybrid method for regional-scale modeling
+
+6. #### Making AxiSEM3d easier to use - improving the workflow for output
+
+
+## Medium Priority Items:
+
+6. #### GPU acceleration
+
+7. #### Local time stepping
+
+8. #### Fluids - attenuation, coupling - solids, fluids, and acoustic
+
+9. #### 3D kernels
+
+10. #### Recompute Instaseis seismograms
+
+
+## Low Priority Items:
+
+11. #### Rotating Earth - for normal mode
+
+12. #### (Self & ) Gravity

--- a/development-priorities.markdown
+++ b/development-priorities.markdown
@@ -4,42 +4,35 @@ title: Development Priorities
 permalink: /development/
 ---
 
-## High Priority Items:
+## High Priority:
 
-1. #### Fix topography on boundaries
-**Issue**: Topography on boundaries fails in unpredictable ways, especially when there are two boundaries close to each other.  
-**Common error message**: "Negative Jacobian"  
-**Possible solution**: adjust smoothing internal to solver before running time loop (like older versions of AxiSEM3D). 
-This is a common failing mode for solutions across a range of scales and problems (Earth, Moon, Mars) and scales (local to global). Is the highest priority item as of 06-2026.  
+- #### Fix topography on boundaries
+**Github Issue**: [#272](https://github.com/AxiSEMunity/AxiSEM3D/issues/272)
 
-2. #### Create a minimum failing example
-**Issue**: In order to make sure that AxiSEM3D stops running whenever it stops outputting NaN results,
-a minimum failing example is needed to reliably produce NaN outputs.
+- #### Output a deformed mesh for checking
 
-3. #### Output a deformed mesh for checking
+- #### Support for planetary simulations - higher frequency
 
-4. #### Support for planetary simulations - higher frequency
+- #### Wavefield injection - implement a hybrid method for regional-scale modeling
 
-5. #### Wavefield injection - implement a hybrid method for regional-scale modeling
-
-6. #### Making AxiSEM3d easier to use - improving the workflow for output
+- #### Making AxiSEM3d easier to use - improving the workflow for output
 
 
-## Medium Priority Items:
+## Medium Priority:
 
-6. #### GPU acceleration
+- #### GPU acceleration
 
-7. #### Local time stepping
+- #### Local time stepping
 
-8. #### Fluids - attenuation, coupling - solids, fluids, and acoustic
+- #### Fluids - attenuation, coupling - solids, fluids, and acoustic
 
-9. #### 3D kernels
+- #### 3D kernels
 
-10. #### Recompute Instaseis seismograms
+- #### Recompute Instaseis seismograms
 
 
-## Low Priority Items:
+## Low Priority:
 
-11. #### Rotating Earth - for normal mode
+- #### Rotating Earth - for normal modes
 
-12. #### (Self & ) Gravity
+- #### (Self & ) Gravity

--- a/development-priorities.markdown
+++ b/development-priorities.markdown
@@ -4,35 +4,8 @@ title: Development Priorities
 permalink: /development/
 ---
 
-## High Priority:
+## [High Priority](https://github.com/AxiSEMunity/AxiSEM3D/issues?q=is%3Aissue%20state%3Aopen%20label%3ADEV%3Ahigh)
 
-- #### Fix topography on boundaries
-**Github Issue**: [#272](https://github.com/AxiSEMunity/AxiSEM3D/issues/272)
+## [Medium Priority](https://github.com/AxiSEMunity/AxiSEM3D/issues?q=is%3Aissue%20state%3Aopen%20label%3ADEV%3Amedium)
 
-- #### Output a deformed mesh for checking
-
-- #### Support for planetary simulations - higher frequency
-
-- #### Wavefield injection - implement a hybrid method for regional-scale modeling
-
-- #### Making AxiSEM3d easier to use - improving the workflow for output
-
-
-## Medium Priority:
-
-- #### GPU acceleration
-
-- #### Local time stepping
-
-- #### Fluids - attenuation, coupling - solids, fluids, and acoustic
-
-- #### 3D kernels
-
-- #### Recompute Instaseis seismograms
-
-
-## Low Priority:
-
-- #### Rotating Earth - for normal modes
-
-- #### (Self & ) Gravity
+## [Low Priority](https://github.com/AxiSEMunity/AxiSEM3D/issues?q=is%3Aissue%20state%3Aopen%20label%3ADEV%3Alow)


### PR DESCRIPTION
Adds a webpage to the axisem github pages which lists the current development priorities from this [spreadsheet](https://docs.google.com/spreadsheets/d/1Uh9tZzmvfwbYs2taQece81tJbW7zUGwnPStT1sjX7ak/edit?gid=0#gid=0);