### PR TITLE
Adds development priorities to documentation

### DIFF
--- a/doc/sphinx/source/intro.md
+++ b/doc/sphinx/source/intro.md
@@ -194,4 +194,4 @@ See also [CONTRIBUTING.md](../../../CONTRIBUTING.md).
 ### Development
 AxiSEM3D is being developed as a community code project. As such, we rely on the community to help maintain and contiribute new features to the code.
 
-Development priorities arise from community consensus. The developoment priorites are maaintained as separate [GitHub issues](https://github.com/AxiSEMunity/AxiSEM3D/issues?q=is%3Aissue%20state%3Aopen%20label%3ADEV%3Ahigh%2CDEV%3Alow%2CDEV%3Amedium) and maybe assigned high, medium, or low priority according to community ranking.
+Development priorities arise from community consensus. The development priorites are maintained as separate [GitHub issues](https://github.com/AxiSEMunity/AxiSEM3D/issues?q=is%3Aissue%20state%3Aopen%20label%3ADEV%3Ahigh%2CDEV%3Alow%2CDEV%3Amedium) and maybe assigned high, medium, or low priority according to community ranking.

--- a/doc/sphinx/source/intro.md
+++ b/doc/sphinx/source/intro.md
@@ -184,3 +184,14 @@ Then add the following to your data availability statement:
 Please consider using the following text in your Acknowledgments section:
 
     We thank ....
+
+### Getting Help
+
+For questions about AxiSEM3D on all levels, please use the [AxiSEM3D forum](https://community.geodynamics.org/c/axisem).
+
+See also [CONTRIBUTING.md](../../../CONTRIBUTING.md).
+
+### Development
+AxiSEM3D is being developed as a community code project. As such, we rely on the community to help maintain and contiribute new features to the code.
+
+Development priorities arise from community consensus. The developoment priorites are maaintained as separate [GitHub issues](https://github.com/AxiSEMunity/AxiSEM3D/issues?q=is%3Aissue%20state%3Aopen%20label%3ADEV%3Ahigh%2CDEV%3Alow%2CDEV%3Amedium) and maybe assigned high, medium, or low priority according to community ranking.


### PR DESCRIPTION
This adds to new headers to the Introduction:

*Getting help

* Development. This links to GitHub issues. If the language looks good here, I would suggest also copying it to the website. In this manner we are only keeping this in one place. 