### PR TITLE
add _site directory and Gemfile to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,3 +47,7 @@ examples/*/output__backup_at_*/
 
 # Documentation
 .venv
+
+# Website Files
+_site/
+Gemfile.lock


### PR DESCRIPTION
When generating the website files to test running locally from the www branch a directory called `_site` is created which holds the generated website files. This adds that directory to the .gitignore file since I don't think the generated site files would be edited directly.