### PR TITLE
add tests/*/output__backup_at_*/ to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,7 +44,7 @@ build*/
 .cache/
 examples/*/output/
 examples/*/output__backup_at_*/
-
+tests/*/output__backup_at_*/
 # Documentation
 .venv
 


### PR DESCRIPTION
 `examples/*/output__backup_at_*/` was already in the gitignore file, but when adding a test often output backups are generated in the tests directory so this adds those to the gitignore.