### PR TITLE
Add debug build to cmake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -248,18 +248,35 @@ ${CPP_FILES}
 external/yaml/Yaml.cpp
 )
 
+# add all source files to the debug executable
+add_executable(
+axisem3d-debug
+# src
+${CPP_FILES}
+# non-header-only local externals
+external/yaml/Yaml.cpp
+)
+
 # standard C++17
 set_property(TARGET axisem3d PROPERTY CXX_STANDARD 17)
+set_property(TARGET axisem3d-debug PROPERTY CXX_STANDARD 17)
+
 
 # compiler flags
 # user-provided extra flags (space-separated string supported)
 if(NOT "${ADDITIONAL_CXX_FLAGS}" STREQUAL "")
   separate_arguments(_A3D_USER_CXX_FLAGS NATIVE_COMMAND "${ADDITIONAL_CXX_FLAGS}")
   target_compile_options(axisem3d PRIVATE ${_A3D_USER_CXX_FLAGS})
+  target_compile_options(axisem3d-debug PRIVATE ${_A3D_USER_CXX_FLAGS})
 endif()
+
+# Make sure to compile the debug target with debug symbols
+# and no optimizations
+target_compile_options(axisem3d-debug PRIVATE -g -O0)
 
 # suppress #pragma warnings
 target_compile_options(axisem3d PRIVATE -Wno-unknown-pragmas)
+target_compile_options(axisem3d-debug PRIVATE -Wno-unknown-pragmas)
 
 
 ################# linking #################
@@ -271,14 +288,24 @@ target_link_libraries(
     ${NETCDF_LIBRARIES}
   )
 
+target_link_libraries(
+    axisem3d-debug
+    ${MPI_CXX_LIBRARIES}
+    ${FFTW3_LIBRARIES}
+    ${METIS_LIBRARIES}
+    ${NETCDF_LIBRARIES}
+  )
+
 if(WITH_HDF5)
   target_link_libraries(axisem3d ${HDF5_HL_LIBRARIES} ${HDF5_LIBRARIES})
+  target_link_libraries(axisem3d-debug ${HDF5_HL_LIBRARIES} ${HDF5_LIBRARIES})
 endif()
 
 # additional user link options (space-separated string supported)
 if(NOT "${ADDITIONAL_LINK_OPTIONS}" STREQUAL "")
   separate_arguments(_A3D_USER_LINK_OPTIONS NATIVE_COMMAND "${ADDITIONAL_LINK_OPTIONS}")
   target_link_options(axisem3d PRIVATE ${_A3D_USER_LINK_OPTIONS})
+  target_link_options(axisem3d-debug PRIVATE ${_A3D_USER_LINK_OPTIONS})
 endif()
 
 # target to run tools/indent.sh (clang-format) from project root

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -257,17 +257,23 @@ ${CPP_FILES}
 external/yaml/Yaml.cpp
 )
 
-# standard C++17
-set_property(TARGET axisem3d PROPERTY CXX_STANDARD 17)
-set_property(TARGET axisem3d-debug PROPERTY CXX_STANDARD 17)
+# Create a list with both executables, so that we can loop through them
+# when setting properties shared by both.
+list(APPEND TARGET_EXECUTABLES axisem3d)
+list(APPEND TARGET_EXECUTABLES axisem3d-debug)
 
+# standard C++17
+foreach(_T ${TARGET_EXECUTABLES})
+  set_property(TARGET ${_T} PROPERTY CXX_STANDARD 17)
+endforeach()
 
 # compiler flags
 # user-provided extra flags (space-separated string supported)
 if(NOT "${ADDITIONAL_CXX_FLAGS}" STREQUAL "")
   separate_arguments(_A3D_USER_CXX_FLAGS NATIVE_COMMAND "${ADDITIONAL_CXX_FLAGS}")
-  target_compile_options(axisem3d PRIVATE ${_A3D_USER_CXX_FLAGS})
-  target_compile_options(axisem3d-debug PRIVATE ${_A3D_USER_CXX_FLAGS})
+  foreach(_T ${TARGET_EXECUTABLES})
+    target_compile_options(${_T} PRIVATE ${_A3D_USER_CXX_FLAGS})
+  endforeach()
 endif()
 
 # Make sure to compile the debug target with debug symbols
@@ -275,37 +281,33 @@ endif()
 target_compile_options(axisem3d-debug PRIVATE -g -O0)
 
 # suppress #pragma warnings
-target_compile_options(axisem3d PRIVATE -Wno-unknown-pragmas)
-target_compile_options(axisem3d-debug PRIVATE -Wno-unknown-pragmas)
-
+foreach(_T ${TARGET_EXECUTABLES})
+  target_compile_options(${_T} PRIVATE -Wno-unknown-pragmas)
+endforeach()
 
 ################# linking #################
-target_link_libraries(
-    axisem3d
-    ${MPI_CXX_LIBRARIES}
-    ${FFTW3_LIBRARIES}
-    ${METIS_LIBRARIES}
-    ${NETCDF_LIBRARIES}
-  )
-
-target_link_libraries(
-    axisem3d-debug
-    ${MPI_CXX_LIBRARIES}
-    ${FFTW3_LIBRARIES}
-    ${METIS_LIBRARIES}
-    ${NETCDF_LIBRARIES}
-  )
+foreach(_T ${TARGET_EXECUTABLES})
+  target_link_libraries(
+      ${_T}
+      ${MPI_CXX_LIBRARIES}
+      ${FFTW3_LIBRARIES}
+      ${METIS_LIBRARIES}
+      ${NETCDF_LIBRARIES}
+    )
+endforeach()
 
 if(WITH_HDF5)
-  target_link_libraries(axisem3d ${HDF5_HL_LIBRARIES} ${HDF5_LIBRARIES})
-  target_link_libraries(axisem3d-debug ${HDF5_HL_LIBRARIES} ${HDF5_LIBRARIES})
+  foreach(_T ${TARGET_EXECUTABLES})
+      target_link_libraries(${_T} ${HDF5_HL_LIBRARIES} ${HDF5_LIBRARIES})
+  endforeach()
 endif()
 
 # additional user link options (space-separated string supported)
 if(NOT "${ADDITIONAL_LINK_OPTIONS}" STREQUAL "")
   separate_arguments(_A3D_USER_LINK_OPTIONS NATIVE_COMMAND "${ADDITIONAL_LINK_OPTIONS}")
-  target_link_options(axisem3d PRIVATE ${_A3D_USER_LINK_OPTIONS})
-  target_link_options(axisem3d-debug PRIVATE ${_A3D_USER_LINK_OPTIONS})
+  foreach(_T ${TARGET_EXECUTABLES})
+    target_link_options(${_T} PRIVATE ${_A3D_USER_LINK_OPTIONS})
+  endforeach()
 endif()
 
 # target to run tools/indent.sh (clang-format) from project root

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,6 +9,10 @@ if(DEFINED cxx AND NOT cxx STREQUAL "")
   set(CMAKE_CXX_COMPILER "${cxx}" CACHE FILEPATH "C++ compiler" FORCE)
 endif()
 
+if(NOT DEFINED COMPILE_DEBUG_EXECUTABLE)
+    set(COMPILE_DEBUG_EXECUTABLE ON CACHE BOOL "If OFF, only compile the optimized axisem3d executable.")
+endif()
+
 # additional compiler flags
 set(ADDITIONAL_CXX_FLAGS "${flags}")
 
@@ -260,8 +264,11 @@ external/yaml/Yaml.cpp
 # Create a list with both executables, so that we can loop through them
 # when setting properties shared by both.
 list(APPEND TARGET_EXECUTABLES axisem3d)
-list(APPEND TARGET_EXECUTABLES axisem3d-debug)
-
+# Do not compile axisem3d-debug if the user doesn't want it
+# compiled
+if(COMPILE_DEBUG_EXECUTABLE)
+  list(APPEND TARGET_EXECUTABLES axisem3d-debug)
+endif()
 # standard C++17
 foreach(_T ${TARGET_EXECUTABLES})
   set_property(TARGET ${_T} PROPERTY CXX_STANDARD 17)

--- a/doc/sphinx/source/installation/solver/index.md
+++ b/doc/sphinx/source/installation/solver/index.md
@@ -42,7 +42,7 @@ easiest way. If necessary, the following CMake options can be specified (using t
 | USE_PARALLEL_NETCDF | OFF | If set to ON, AxiSEM3D will write netCDF output with parallel routines. |
 | WITH_HDF5 | ON | If set to OFF or HDF5 is not found, disable HDF5 support |
 | HDF5_DIR | | Optional hint to the HDF5 directory |
-| COMPILE_DEBUG_EXECUTABLE | ON | Set to OFF to stop cmake from compilining axisem3d-debug executable alongside the optimized axisem3d executable |
+| COMPILE_DEBUG_EXECUTABLE | ON | Set to OFF to stop cmake from compiling axisem3d-debug executable alongside the optimized axisem3d executable |
 ---
 
 ```{toctree}

--- a/doc/sphinx/source/installation/solver/index.md
+++ b/doc/sphinx/source/installation/solver/index.md
@@ -42,7 +42,7 @@ easiest way. If necessary, the following CMake options can be specified (using t
 | USE_PARALLEL_NETCDF | OFF | If set to ON, AxiSEM3D will write netCDF output with parallel routines. |
 | WITH_HDF5 | ON | If set to OFF or HDF5 is not found, disable HDF5 support |
 | HDF5_DIR | | Optional hint to the HDF5 directory |
-
+| COMPILE_DEBUG_EXECUTABLE | ON | Set to OFF to stop cmake from compilining axisem3d-debug executable alongside the optimized axisem3d executable |
 ---
 
 ```{toctree}


### PR DESCRIPTION
This makes cmake build an `axisem3d-debug` executable alongside the `axisem3d` executable. `axisem3d-debug` has debug symbols enabled and optimizations turned off. There is also a `COMPILE_DEBUG_EXECUTABLE` configuration variable which you can set to off if you only want to compile the optimized version.

This does make the compilation take a bit longer since it now compiles another executable. When I did a rough speed test on my computer using 1 processor compilation takes about twice as long (which seems expected).

I thought this might be useful even though using `-DCMAKE_BUILD_TYPE=Debug` does already work. My thinking is that it is likely that people who are compiling axisem multiple times may be more likely to be contributing code to axisem and are compiling it for testing (and so are more likely to want a debug mode) while more casual users may only compile axisem occasionally. For people who only occasionally compile axisem and don't need debugging tools, they can set `COMPILE_DEBUG_EXECUTABLE=OFF` if they want to compile faster.