### PR TITLE
Add smoothing and Jacobian checks for geometric models

### DIFF
--- a/doc/sphinx/source/methods/undulations.md
+++ b/doc/sphinx/source/methods/undulations.md
@@ -51,3 +51,19 @@ transformation’s Jacobian. Things get unstable when the Jacobian becomes
 negative or otherwise badly behaved; physically this corresponds to
 elements doing things that they should not be doing (becoming overly
 stretched, crossing into other elements, etc).
+
+A value of 1 represents an undeformed mapping and a value approaching 0
+represents a mapping approaching singularity. AxiSEM3D checks the final,
+combined geometric deformation during preloop. The global threshold is
+configured in `inparam.advanced.yaml`:
+
+```yaml
+minimum_jacobian: 0.1
+```
+
+The value is dimensionless and must be non-negative. If a sampled
+Jacobian is below the threshold, AxiSEM3D reports both values and aborts
+before the time loop. Lowering the threshold accepts more severe
+distortion; it does not improve or repair the geometry. Prefer first to
+check the model units and undulation ranges, then adjust the deformation
+range or use the [clamping and smoothing options](../user/models/geometric.md#clamping-and-smoothing-undulations).

--- a/doc/sphinx/source/parameter/advanced.md
+++ b/doc/sphinx/source/parameter/advanced.md
@@ -1,5 +1,24 @@
 # inparam.advanced.yaml
 
+## geometric deformation
+
+### `minimum_jacobian`
+
+**What:** minimum acceptable Jacobian after applying geometric models
+
+**Type:** double
+
+**Default:** `0.1`
+
+**Note:**
+
+1) dimensionless; the undeformed value is 1, while 0 is singular
+2) checked after all geometric models have been combined; the solver
+aborts during preloop if any sampled value is below this threshold
+3) must be non-negative; decreasing it permits stronger distortion but
+does not repair the input geometry
+
+
 ## verbosity
 
 Parameters for verbosity.

--- a/doc/sphinx/source/user/models/geometric.md
+++ b/doc/sphinx/source/user/models/geometric.md
@@ -51,6 +51,63 @@ latitude and longitude each at a spacing of 1°, that gives you 180 ×
 elevation or depth. You can choose the spacing that you want: 1° is
 probably fine for most things.
 
+(clamping-and-smoothing-undulations)=
+## Clamping and smoothing undulations
+
+`StructuredGridG3D` and `Crust1G3D` can clamp and Gaussian-smooth their
+undulation data during model initialisation. This operates on the
+undulation, such as `dz`, rather than on an absolute interface radius or
+depth. The NetCDF file itself is not modified.
+
+For a structured-grid geometric model, add the following block alongside
+`undulation_data`:
+
+```yaml
+undulation_data:
+    nc_var: elevation
+    factor: 1.0
+clamp_smooth:
+    enabled: true
+    clamp_range: [-10000.0, 10000.0]
+    sigma_degree_or_meter: 1.0
+```
+
+The operations are applied in this order:
+
+1. Multiply the input undulation by `undulation_data:factor` (or by the
+   corresponding surface/Moho factor in `Crust1G3D`).
+2. Clamp the scaled undulation to `clamp_range`.
+3. Apply a two-dimensional Gaussian filter to the clamped field.
+
+The parameters are:
+
+- `enabled`: enables both clamping and smoothing. It defaults to `true`
+  for `Crust1G3D` and to `false` for other geometric models. An explicit
+  value always overrides the model default.
+- `clamp_range`: the inclusive minimum and maximum undulation in metres.
+  It must contain two ascending values. The default
+  `[-1e10, 1e10]` effectively disables clamping for normal models.
+- `sigma_degree_or_meter`: the Gaussian standard deviation. It must be
+  positive and defaults to `1`. Its unit is degrees for spherical models
+  and metres for Cartesian models. The Gaussian is internally truncated
+  at four standard deviations.
+
+Smoothing requires a uniformly spaced horizontal grid. In Cartesian
+geometry it is supported on `XY_CARTESIAN` grids, where both axes and
+`sigma_degree_or_meter` are in metres. In spherical geometry the sigma is
+always specified in degrees, including for source-centred
+`DISTANCE_AZIMUTH` grids.
+
+For `StructuredGridG3D`, the filter uses nearest-value padding at every
+grid edge and does not wrap longitude or azimuth periodically. A global
+or periodic user model must therefore provide suitable and mutually
+consistent values at its grid boundaries. The built-in `Crust1G3D`
+model has known global topology, so it always wraps longitude while
+keeping nearest-value padding in latitude. Filtering can reduce steep
+gradients and often prevent distorted elements, but it is not an
+automatic geometry repair: users should inspect the scientific loss
+caused by the selected clamp and sigma.
+
 ## Creating new geometric models
 
 The base structure for global scale, 3D geometric models is included in

--- a/doc/sphinx/source/user/settings/index.md
+++ b/doc/sphinx/source/user/settings/index.md
@@ -1,6 +1,20 @@
 # Advanced settings
 
-The input file `inparam.advanced.yaml` contains several advanced settings. Most of these parameters facilitate code development and are usually not of users' interest except `nproc_per_group` under `mpi`, which is important for large-scale computations.
+The input file `inparam.advanced.yaml` contains several advanced settings.
+Most facilitate code development, but `minimum_jacobian` is important for
+geometric models and `nproc_per_group` under `mpi` is important for
+large-scale computations.
+
+**`minimum_jacobian`**
+
+This dimensionless value is the global acceptance threshold for the final
+particle-relabeling transformation after all geometric models have been
+combined. The default is `0.1`; an undeformed mapping has a value of 1 and
+a singular mapping has a value of 0. AxiSEM3D aborts during preloop if a
+sampled Jacobian is smaller than the threshold. Lowering this value allows
+more distorted elements but does not repair them. See
+[More on undulation](../../methods/undulations.md) and
+[Clamping and smoothing undulations](../models/geometric.md#clamping-and-smoothing-undulations).
 
 
 **`verbose`**
@@ -24,4 +38,3 @@ Any number in between is reasonable. If the program is terminated by a memory er
 
 **`develop`**
 The parameters under `develop` are mostly for developers. `max_num_time_steps` can be a useful one for users, which allows you to run only one time step to validate the input files. 
-

--- a/doc/sphinx/source/user/solver/y_advanced.md
+++ b/doc/sphinx/source/user/solver/y_advanced.md
@@ -4,6 +4,18 @@ It is unlikely that you will need to change anything in this file, as
 the options are quite technical and likely of limited interest to the
 casual user. 
 
+**geometric deformation**
+```yaml
+minimum_jacobian: 0.1
+```
+
+`minimum_jacobian` is the dimensionless lower limit accepted for the
+final particle-relabeling Jacobian after all geometric models have been
+applied. The undeformed value is 1 and 0 is singular. If the limit is
+violated, the run stops during preloop and reports both the observed and
+configured values. Lowering the limit accepts stronger distortion; it
+does not smooth or otherwise repair the geometry.
+
 **verbosity**
 ```
 verbose:

--- a/examples/00_global_1D/input/inparam.advanced.yaml
+++ b/examples/00_global_1D/input/inparam.advanced.yaml
@@ -10,6 +10,17 @@
 #  advanced settings
 
 
+##################### geometric deformation #####################
+# what: minimum acceptable Jacobian after applying geometric models
+# type: double
+# note: 1) dimensionless; the undeformed value is 1, while 0 is singular
+#       2) checked after all geometric models have been combined; the solver
+#          aborts during preloop if any sampled value is below this threshold
+#       3) must be non-negative; decreasing it permits stronger distortion but
+#          does not repair the input geometry
+minimum_jacobian: 0.1
+
+
 ##################### verbosity #####################
 # parameters for verbosity
 verbose:

--- a/examples/01_S362ANI_EMC_global/input/inparam.advanced.yaml
+++ b/examples/01_S362ANI_EMC_global/input/inparam.advanced.yaml
@@ -10,6 +10,17 @@
 #  advanced settings
 
 
+##################### geometric deformation #####################
+# what: minimum acceptable Jacobian after applying geometric models
+# type: double
+# note: 1) dimensionless; the undeformed value is 1, while 0 is singular
+#       2) checked after all geometric models have been combined; the solver
+#          aborts during preloop if any sampled value is below this threshold
+#       3) must be non-negative; decreasing it permits stronger distortion but
+#          does not repair the input geometry
+minimum_jacobian: 0.1
+
+
 ##################### verbosity #####################
 # parameters for verbosity
 verbose:

--- a/examples/02_3d_crust_S362ANI_regional/input_share/inparam.advanced.yaml
+++ b/examples/02_3d_crust_S362ANI_regional/input_share/inparam.advanced.yaml
@@ -10,6 +10,17 @@
 #  advanced settings
 
 
+##################### geometric deformation #####################
+# what: minimum acceptable Jacobian after applying geometric models
+# type: double
+# note: 1) dimensionless; the undeformed value is 1, while 0 is singular
+#       2) checked after all geometric models have been combined; the solver
+#          aborts during preloop if any sampled value is below this threshold
+#       3) must be non-negative; decreasing it permits stronger distortion but
+#          does not repair the input geometry
+minimum_jacobian: 0.1
+
+
 ##################### verbosity #####################
 # parameters for verbosity
 verbose:

--- a/examples/02_3d_crust_S362ANI_regional/input_with_3d_crust/inparam.model.yaml
+++ b/examples/02_3d_crust_S362ANI_regional/input_with_3d_crust/inparam.model.yaml
@@ -264,8 +264,10 @@ list_of_3D_models:
         ellipticity: true
         surface_factor: 1
         moho_factor: 1
-        gaussian_order: 2
-        gaussian_deviation: 0.5
+        clamp_smooth:
+            enabled: true
+            clamp_range: [-1e10, 1e10]
+            sigma_degree_or_meter: 1
     #==========================================================================#
     # this key can be arbitrary
     - CRUST1_O3D:

--- a/examples/02_3d_crust_S362ANI_regional/input_with_3d_crust/inparam.model.yaml
+++ b/examples/02_3d_crust_S362ANI_regional/input_with_3d_crust/inparam.model.yaml
@@ -264,6 +264,8 @@ list_of_3D_models:
         ellipticity: true
         surface_factor: 1
         moho_factor: 1
+        # clamp in metres, then Gaussian-smooth the native Crust1 grid
+        # sigma_degree_or_meter is in degrees for this spherical grid
         clamp_smooth:
             enabled: true
             clamp_range: [-1e10, 1e10]

--- a/examples/03_salt_body_SEG_local/input1D/inparam.advanced.yaml
+++ b/examples/03_salt_body_SEG_local/input1D/inparam.advanced.yaml
@@ -10,6 +10,17 @@
 #  advanced settings
 
 
+##################### geometric deformation #####################
+# what: minimum acceptable Jacobian after applying geometric models
+# type: double
+# note: 1) dimensionless; the undeformed value is 1, while 0 is singular
+#       2) checked after all geometric models have been combined; the solver
+#          aborts during preloop if any sampled value is below this threshold
+#       3) must be non-negative; decreasing it permits stronger distortion but
+#          does not repair the input geometry
+minimum_jacobian: 0.1
+
+
 ##################### verbosity #####################
 # parameters for verbosity
 verbose:

--- a/examples/03_salt_body_SEG_local/input3D/inparam.advanced.yaml
+++ b/examples/03_salt_body_SEG_local/input3D/inparam.advanced.yaml
@@ -10,6 +10,17 @@
 #  advanced settings
 
 
+##################### geometric deformation #####################
+# what: minimum acceptable Jacobian after applying geometric models
+# type: double
+# note: 1) dimensionless; the undeformed value is 1, while 0 is singular
+#       2) checked after all geometric models have been combined; the solver
+#          aborts during preloop if any sampled value is below this threshold
+#       3) must be non-negative; decreasing it permits stronger distortion but
+#          does not repair the input geometry
+minimum_jacobian: 0.1
+
+
 ##################### verbosity #####################
 # parameters for verbosity
 verbose:

--- a/examples/03_salt_body_SEG_local/input3D/inparam.model.yaml
+++ b/examples/03_salt_body_SEG_local/input3D/inparam.model.yaml
@@ -323,6 +323,10 @@ list_of_3D_models:
             nc_var: depth
             # what: factor or unit
             factor: 1.
+        clamp_smooth:
+            enabled: false
+            clamp_range: [-1e10, 1e10]
+            sigma_degree_or_meter: 1
         # what: store grid data only on the leader processors
         # type: bool
         # note: turn this on if the model is large; set mpi:nproc_per_group

--- a/examples/03_salt_body_SEG_local/input3D/inparam.model.yaml
+++ b/examples/03_salt_body_SEG_local/input3D/inparam.model.yaml
@@ -323,6 +323,8 @@ list_of_3D_models:
             nc_var: depth
             # what: factor or unit
             factor: 1.
+        # clamp in metres, then Gaussian-smooth the native horizontal grid
+        # sigma_degree_or_meter is in metres for a Cartesian XY grid
         clamp_smooth:
             enabled: false
             clamp_range: [-1e10, 1e10]

--- a/examples/04_simple_3d_shapes/example_input_cartesian/inparam.advanced.yaml
+++ b/examples/04_simple_3d_shapes/example_input_cartesian/inparam.advanced.yaml
@@ -10,6 +10,17 @@
 #  advanced settings
 
 
+##################### geometric deformation #####################
+# what: minimum acceptable Jacobian after applying geometric models
+# type: double
+# note: 1) dimensionless; the undeformed value is 1, while 0 is singular
+#       2) checked after all geometric models have been combined; the solver
+#          aborts during preloop if any sampled value is below this threshold
+#       3) must be non-negative; decreasing it permits stronger distortion but
+#          does not repair the input geometry
+minimum_jacobian: 0.1
+
+
 ##################### verbosity #####################
 # parameters for verbosity
 verbose:

--- a/examples/04_simple_3d_shapes/example_release_paper/input/inparam.advanced.yaml
+++ b/examples/04_simple_3d_shapes/example_release_paper/input/inparam.advanced.yaml
@@ -10,6 +10,17 @@
 #  advanced settings
 
 
+##################### geometric deformation #####################
+# what: minimum acceptable Jacobian after applying geometric models
+# type: double
+# note: 1) dimensionless; the undeformed value is 1, while 0 is singular
+#       2) checked after all geometric models have been combined; the solver
+#          aborts during preloop if any sampled value is below this threshold
+#       3) must be non-negative; decreasing it permits stronger distortion but
+#          does not repair the input geometry
+minimum_jacobian: 0.1
+
+
 ##################### verbosity #####################
 # parameters for verbosity
 verbose:

--- a/examples/04_simple_3d_shapes/example_single_plume/inparam.advanced.yaml
+++ b/examples/04_simple_3d_shapes/example_single_plume/inparam.advanced.yaml
@@ -10,6 +10,17 @@
 #  advanced settings
 
 
+##################### geometric deformation #####################
+# what: minimum acceptable Jacobian after applying geometric models
+# type: double
+# note: 1) dimensionless; the undeformed value is 1, while 0 is singular
+#       2) checked after all geometric models have been combined; the solver
+#          aborts during preloop if any sampled value is below this threshold
+#       3) must be non-negative; decreasing it permits stronger distortion but
+#          does not repair the input geometry
+minimum_jacobian: 0.1
+
+
 ##################### verbosity #####################
 # parameters for verbosity
 verbose:

--- a/examples/05_anisotropy_global/2012-07-03_paper_example_50s/sim_US32_olivineE/input/inparam.advanced.yaml
+++ b/examples/05_anisotropy_global/2012-07-03_paper_example_50s/sim_US32_olivineE/input/inparam.advanced.yaml
@@ -10,6 +10,17 @@
 #  advanced settings
 
 
+##################### geometric deformation #####################
+# what: minimum acceptable Jacobian after applying geometric models
+# type: double
+# note: 1) dimensionless; the undeformed value is 1, while 0 is singular
+#       2) checked after all geometric models have been combined; the solver
+#          aborts during preloop if any sampled value is below this threshold
+#       3) must be non-negative; decreasing it permits stronger distortion but
+#          does not repair the input geometry
+minimum_jacobian: 0.1
+
+
 ##################### verbosity #####################
 # parameters for verbosity
 verbose:

--- a/examples/05_anisotropy_global/2012-07-03_paper_example_50s/sim_US32_olivineE_fullNU/input/inparam.advanced.yaml
+++ b/examples/05_anisotropy_global/2012-07-03_paper_example_50s/sim_US32_olivineE_fullNU/input/inparam.advanced.yaml
@@ -10,6 +10,17 @@
 #  advanced settings
 
 
+##################### geometric deformation #####################
+# what: minimum acceptable Jacobian after applying geometric models
+# type: double
+# note: 1) dimensionless; the undeformed value is 1, while 0 is singular
+#       2) checked after all geometric models have been combined; the solver
+#          aborts during preloop if any sampled value is below this threshold
+#       3) must be non-negative; decreasing it permits stronger distortion but
+#          does not repair the input geometry
+minimum_jacobian: 0.1
+
+
 ##################### verbosity #####################
 # parameters for verbosity
 verbose:

--- a/examples/05_anisotropy_global/PREM_anisotropy_w_and_wo_full_Cij_50s/sim1_ani_prem_mesh/input/inparam.advanced.yaml
+++ b/examples/05_anisotropy_global/PREM_anisotropy_w_and_wo_full_Cij_50s/sim1_ani_prem_mesh/input/inparam.advanced.yaml
@@ -10,6 +10,17 @@
 #  advanced settings
 
 
+##################### geometric deformation #####################
+# what: minimum acceptable Jacobian after applying geometric models
+# type: double
+# note: 1) dimensionless; the undeformed value is 1, while 0 is singular
+#       2) checked after all geometric models have been combined; the solver
+#          aborts during preloop if any sampled value is below this threshold
+#       3) must be non-negative; decreasing it permits stronger distortion but
+#          does not repair the input geometry
+minimum_jacobian: 0.1
+
+
 ##################### verbosity #####################
 # parameters for verbosity
 verbose:

--- a/examples/05_anisotropy_global/PREM_anisotropy_w_and_wo_full_Cij_50s/sim2_iso_prem_mesh_plus_ani/input/inparam.advanced.yaml
+++ b/examples/05_anisotropy_global/PREM_anisotropy_w_and_wo_full_Cij_50s/sim2_iso_prem_mesh_plus_ani/input/inparam.advanced.yaml
@@ -10,6 +10,17 @@
 #  advanced settings
 
 
+##################### geometric deformation #####################
+# what: minimum acceptable Jacobian after applying geometric models
+# type: double
+# note: 1) dimensionless; the undeformed value is 1, while 0 is singular
+#       2) checked after all geometric models have been combined; the solver
+#          aborts during preloop if any sampled value is below this threshold
+#       3) must be non-negative; decreasing it permits stronger distortion but
+#          does not repair the input geometry
+minimum_jacobian: 0.1
+
+
 ##################### verbosity #####################
 # parameters for verbosity
 verbose:

--- a/examples/05_anisotropy_global/deep_mantle_anisotropy_full_Cij_50s/sim_lowermost_mantle_ani/input/inparam.advanced.yaml
+++ b/examples/05_anisotropy_global/deep_mantle_anisotropy_full_Cij_50s/sim_lowermost_mantle_ani/input/inparam.advanced.yaml
@@ -10,6 +10,17 @@
 #  advanced settings
 
 
+##################### geometric deformation #####################
+# what: minimum acceptable Jacobian after applying geometric models
+# type: double
+# note: 1) dimensionless; the undeformed value is 1, while 0 is singular
+#       2) checked after all geometric models have been combined; the solver
+#          aborts during preloop if any sampled value is below this threshold
+#       3) must be non-negative; decreasing it permits stronger distortion but
+#          does not repair the input geometry
+minimum_jacobian: 0.1
+
+
 ##################### verbosity #####################
 # parameters for verbosity
 verbose:

--- a/examples/06_finite_source_local/input/inparam.advanced.yaml
+++ b/examples/06_finite_source_local/input/inparam.advanced.yaml
@@ -10,6 +10,17 @@
 #  advanced settings
 
 
+##################### geometric deformation #####################
+# what: minimum acceptable Jacobian after applying geometric models
+# type: double
+# note: 1) dimensionless; the undeformed value is 1, while 0 is singular
+#       2) checked after all geometric models have been combined; the solver
+#          aborts during preloop if any sampled value is below this threshold
+#       3) must be non-negative; decreasing it permits stronger distortion but
+#          does not repair the input geometry
+minimum_jacobian: 0.1
+
+
 ##################### verbosity #####################
 # parameters for verbosity
 verbose:

--- a/examples/06_finite_source_local/input/inparam.model.yaml
+++ b/examples/06_finite_source_local/input/inparam.model.yaml
@@ -607,6 +607,8 @@ list_of_3D_models:
             nc_var: dz
             # what: factor or unit
             factor: 1.
+        # clamp in metres, then Gaussian-smooth the native horizontal grid
+        # sigma_degree_or_meter is in metres for a Cartesian XY grid
         clamp_smooth:
             enabled: false
             clamp_range: [-1e10, 1e10]
@@ -676,6 +678,8 @@ list_of_3D_models:
             nc_var: dz
             # what: factor or unit
             factor: 1.
+        # clamp in metres, then Gaussian-smooth the native horizontal grid
+        # sigma_degree_or_meter is in metres for a Cartesian XY grid
         clamp_smooth:
             enabled: false
             clamp_range: [-1e10, 1e10]

--- a/examples/06_finite_source_local/input/inparam.model.yaml
+++ b/examples/06_finite_source_local/input/inparam.model.yaml
@@ -607,6 +607,10 @@ list_of_3D_models:
             nc_var: dz
             # what: factor or unit
             factor: 1.
+        clamp_smooth:
+            enabled: false
+            clamp_range: [-1e10, 1e10]
+            sigma_degree_or_meter: 1
         # what: store grid data only on the leader processors
         # type: bool
         # note: turn this on if the model is large; set mpi:nproc_per_group
@@ -672,6 +676,10 @@ list_of_3D_models:
             nc_var: dz
             # what: factor or unit
             factor: 1.
+        clamp_smooth:
+            enabled: false
+            clamp_range: [-1e10, 1e10]
+            sigma_degree_or_meter: 1
         # what: store grid data only on the leader processors
         # type: bool
         # note: turn this on if the model is large; set mpi:nproc_per_group

--- a/examples/07_kernels/kernel_3D/input_forward/inparam.model.yaml
+++ b/examples/07_kernels/kernel_3D/input_forward/inparam.model.yaml
@@ -151,6 +151,10 @@ list_of_3D_models:
         undulation_data:
             nc_var: undulation_MOHO
             factor: 1
+        clamp_smooth:
+            enabled: false
+            clamp_range: [-1e10, 1e10]
+            sigma_degree_or_meter: 1
         store_grid_only_on_leaders: true
 
     - EMC_S362ANI:

--- a/examples/08_atmosphere_Mars_global/axisem3d_mars_atm/input/inparam.advanced.yaml
+++ b/examples/08_atmosphere_Mars_global/axisem3d_mars_atm/input/inparam.advanced.yaml
@@ -10,6 +10,17 @@
 #  advanced settings
 
 
+##################### geometric deformation #####################
+# what: minimum acceptable Jacobian after applying geometric models
+# type: double
+# note: 1) dimensionless; the undeformed value is 1, while 0 is singular
+#       2) checked after all geometric models have been combined; the solver
+#          aborts during preloop if any sampled value is below this threshold
+#       3) must be non-negative; decreasing it permits stronger distortion but
+#          does not repair the input geometry
+minimum_jacobian: 0.1
+
+
 ##################### verbosity #####################
 # parameters for verbosity
 verbose:

--- a/examples/09_icesheet_regional/input/inparam.model.yaml
+++ b/examples/09_icesheet_regional/input/inparam.model.yaml
@@ -342,6 +342,10 @@ list_of_3D_models:
             nc_var: iob
             # what: factor or unit
             factor: 1
+        clamp_smooth:
+            enabled: false
+            clamp_range: [-1e10, 1e10]
+            sigma_degree_or_meter: 1
         # what: store grid data only on the leader processors
         # type: bool
         # note: turn this on if the model is large; set mpi:nproc_per_group
@@ -349,4 +353,3 @@ list_of_3D_models:
         #       node to minimize memory usage
         store_grid_only_on_leaders: true
     #==========================================================================#
-

--- a/examples/template_develop/input/ex02_list_of_3D_models_3d_crust.yaml
+++ b/examples/template_develop/input/ex02_list_of_3D_models_3d_crust.yaml
@@ -132,8 +132,12 @@
         ellipticity: true
         surface_factor: 1
         moho_factor: 1
-        gaussian_order: 2
-        gaussian_deviation: 0.5
+        # clamp in metres, then Gaussian-smooth the native Crust1 grid
+        # sigma_degree_or_meter is in degrees for this spherical grid
+        clamp_smooth:
+            enabled: true
+            clamp_range: [-1e10, 1e10]
+            sigma_degree_or_meter: 1
     #==========================================================================#
     # this key can be arbitrary
     - CRUST1_O3D:

--- a/examples/template_develop/input/ex03_list_of_3D_models.yaml
+++ b/examples/template_develop/input/ex03_list_of_3D_models.yaml
@@ -191,6 +191,12 @@
             nc_var: depth
             # what: factor or unit
             factor: 1.
+        # clamp in metres, then Gaussian-smooth the native horizontal grid
+        # sigma_degree_or_meter is in metres for a Cartesian XY grid
+        clamp_smooth:
+            enabled: false
+            clamp_range: [-1e10, 1e10]
+            sigma_degree_or_meter: 1
         # what: store grid data only on the leader processors
         # type: bool
         # note: turn this on if the model is large; set mpi:nproc_per_group

--- a/examples/template_develop/input/ex06_list_of_3D_models.yaml
+++ b/examples/template_develop/input/ex06_list_of_3D_models.yaml
@@ -475,6 +475,12 @@
             nc_var: dz
             # what: factor or unit
             factor: 1.
+        # clamp in metres, then Gaussian-smooth the native horizontal grid
+        # sigma_degree_or_meter is in metres for a Cartesian XY grid
+        clamp_smooth:
+            enabled: false
+            clamp_range: [-1e10, 1e10]
+            sigma_degree_or_meter: 1
         # what: store grid data only on the leader processors
         # type: bool
         # note: turn this on if the model is large; set mpi:nproc_per_group
@@ -540,6 +546,12 @@
             nc_var: dz
             # what: factor or unit
             factor: 1.
+        # clamp in metres, then Gaussian-smooth the native horizontal grid
+        # sigma_degree_or_meter is in metres for a Cartesian XY grid
+        clamp_smooth:
+            enabled: false
+            clamp_range: [-1e10, 1e10]
+            sigma_degree_or_meter: 1
         # what: store grid data only on the leader processors
         # type: bool
         # note: turn this on if the model is large; set mpi:nproc_per_group

--- a/examples/template_develop/input/inparam.advanced.yaml
+++ b/examples/template_develop/input/inparam.advanced.yaml
@@ -10,6 +10,17 @@
 #  advanced settings
 
 
+##################### geometric deformation #####################
+# what: minimum acceptable Jacobian after applying geometric models
+# type: double
+# note: 1) dimensionless; the undeformed value is 1, while 0 is singular
+#       2) checked after all geometric models have been combined; the solver
+#          aborts during preloop if any sampled value is below this threshold
+#       3) must be non-negative; decreasing it permits stronger distortion but
+#          does not repair the input geometry
+minimum_jacobian: 0.1
+
+
 ##################### verbosity #####################
 # parameters for verbosity
 verbose:

--- a/src/models3D/geometric/Crust1G3D.cpp
+++ b/src/models3D/geometric/Crust1G3D.cpp
@@ -26,12 +26,10 @@ Crust1G3D::Crust1G3D(const std::string& modelName,
     bool ellipticity,
     double surfaceFactor,
     double mohoFactor,
-    int gaussianOrder,
-    double gaussianDev) :
-    Geometric3D(modelName), mRSurf(rSurf), mRMoho(rMoho), mRBase(rBase),
+    const ClampSmoothConfig& clampSmooth) :
+    Geometric3D(modelName, clampSmooth), mRSurf(rSurf), mRMoho(rMoho), mRBase(rBase),
     mIncludeSediment(includeSediment), mIncludeIce(includeIce), mEllipticity(ellipticity),
-    mSurfFactor(surfaceFactor), mMohoFactor(mohoFactor), mGaussianOrder(gaussianOrder),
-    mGaussianDev(gaussianDev) {
+    mSurfFactor(surfaceFactor), mMohoFactor(mohoFactor) {
   // read raw data
   int nrow = sNLat * sNLon;
   eigen::DMatXX elevation = eigen::DMatXX::Zero(nrow, sNLayer);
@@ -80,20 +78,16 @@ Crust1G3D::Crust1G3D(const std::string& modelName,
   // fs.close();
   //////////// plot raw data ////////////
 
-  // Gaussian smoothing
-  eigen::IColX orderRow = eigen::IColX::Constant(sNLat, mGaussianOrder);
-  eigen::IColX orderCol = eigen::IColX::Constant(sNLon, mGaussianOrder);
-  eigen::DColX devRow = eigen::DColX::Constant(sNLat, mGaussianDev);
-  eigen::DColX devCol = eigen::DColX::Constant(sNLon, mGaussianDev);
-  // smooth poles more
-  // int npolar = mGaussianOrder + 1;
-  // int opolar = sNLon;
-  // for (int i = 0; i < npolar; i++) {
-  //     double order = (double)(opolar - mGaussianOrder) / npolar * (npolar - i) + mGaussianOrder;
-  //     orderRow(i) = orderRow(sNLat - 1 - i) = round(order);
-  // }
-  c1_tools::gaussianSmoothing(deltaRSurf, orderRow, devRow, true, orderCol, devCol, false);
-  c1_tools::gaussianSmoothing(deltaRMoho, orderRow, devRow, true, orderCol, devCol, false);
+  // factors are applied before the nonlinear clamp
+  deltaRSurf *= mSurfFactor;
+  deltaRMoho *= mMohoFactor;
+
+  // clamp and Gaussian smoothing on the native 1-degree grid
+  const std::array<double, 2> spacing = {1., 1.};
+  // CRUST1.0 is global: latitude is bounded and longitude is periodic.
+  const std::array<bool, 2> periodicAxes = {false, true};
+  applyClampSmooth(deltaRSurf, spacing, SmoothGridUnit::DEGREE, periodicAxes);
+  applyClampSmooth(deltaRMoho, spacing, SmoothGridUnit::DEGREE, periodicAxes);
 
   // cast to integer theta with unique polar values
   mDeltaRSurf = eigen::DMatXX::Zero(sNLat + 1, sNLon);
@@ -111,10 +105,6 @@ Crust1G3D::Crust1G3D(const std::string& modelName,
   // reverse south to north
   mDeltaRSurf = mDeltaRSurf.colwise().reverse().eval();
   mDeltaRMoho = mDeltaRMoho.colwise().reverse().eval();
-
-  // apply factor
-  mDeltaRSurf *= mSurfFactor;
-  mDeltaRMoho *= mMohoFactor;
 
   // grid lat and lon
   mGridLat = eigen::DColX(sNLat + 1);
@@ -187,8 +177,7 @@ Crust1G3D::verbose() const {
   ss << boxEquals(2, 22, "ellipticity correction", mEllipticity);
   ss << boxEquals(2, 22, "surface factor", mSurfFactor);
   ss << boxEquals(2, 22, "moho factor", mMohoFactor);
-  ss << boxEquals(2, 22, "Gaussian order", mGaussianOrder);
-  ss << boxEquals(2, 22, "Gaussian factor", mGaussianDev);
+  ss << verboseClampSmooth(2, 22);
   return ss.str();
 }
 

--- a/src/models3D/geometric/Crust1G3D.hpp
+++ b/src/models3D/geometric/Crust1G3D.hpp
@@ -26,8 +26,7 @@ class Crust1G3D : public Geometric3D {
       bool ellipticity,
       double surfaceFactor,
       double mohoFactor,
-      int gaussianOrder,
-      double gaussianDev);
+      const ClampSmoothConfig& clampSmooth);
 
   private:
   // get undulation on an element
@@ -69,10 +68,6 @@ class Crust1G3D : public Geometric3D {
   // strengthening factor
   const double mSurfFactor;
   const double mMohoFactor;
-
-  // smoothening
-  const int mGaussianOrder;
-  const double mGaussianDev;
 
   // deltaR at surface and moho
   eigen::DMatXX mDeltaRSurf;

--- a/src/models3D/geometric/Geometric3D.cpp
+++ b/src/models3D/geometric/Geometric3D.cpp
@@ -12,6 +12,136 @@
 #include "Geometric3D.hpp"
 #include "Quad.hpp"
 #include "mpi.hpp"
+#include "bstring.hpp"
+#include "inparam.hpp"
+#include <cmath>
+
+namespace {
+  // skimage/scipy default; intentionally not exposed in YAML
+  constexpr double sGaussianTruncate = 4.;
+
+  ClampSmoothConfig
+  readClampSmooth(const InparamYAML& gm,
+      const std::string& root,
+      const std::string& modelName,
+      const std::string& className) {
+    ClampSmoothConfig config;
+    // Crust1 keeps smoothing on by default; other geometric models opt in
+    config.enabled = className == "Crust1G3D";
+
+    const std::string roots = root + ":clamp_smooth";
+    if (gm.contains(roots)) {
+      if (gm.contains(roots + ":enabled")) {
+        config.enabled = gm.get<bool>(roots + ":enabled");
+      }
+      if (gm.contains(roots + ":clamp_range")) {
+        const std::vector<double>& range = gm.getVector<double>(roots + ":clamp_range");
+        if (range.size() != 2) {
+          throw std::runtime_error("Geometric3D::buildInparam || "
+                                   "clamp_smooth:clamp_range must contain two values. || "
+                                   "Model name: " +
+              modelName + " || Class name: " + className);
+        }
+        config.clampMin = range[0];
+        config.clampMax = range[1];
+      }
+      if (gm.contains(roots + ":sigma_degree_or_meter")) {
+        config.sigmaDegreeOrMeter = gm.get<double>(roots + ":sigma_degree_or_meter");
+      }
+    }
+
+    if (config.clampMin > config.clampMax) {
+      throw std::runtime_error("Geometric3D::buildInparam || "
+                               "clamp_smooth:clamp_range must be ascending. || "
+                               "Model name: " +
+          modelName + " || Class name: " + className);
+    }
+    if (config.enabled &&
+        (!(config.sigmaDegreeOrMeter > 0.) || !std::isfinite(config.sigmaDegreeOrMeter))) {
+      throw std::runtime_error("Geometric3D::buildInparam || "
+                               "clamp_smooth:sigma_degree_or_meter must be positive and finite. || "
+                               "Model name: " +
+          modelName + " || Class name: " + className);
+    }
+    return config;
+  }
+} // namespace
+
+// clamp in metres, then smooth on the model's native horizontal grid
+void
+Geometric3D::applyClampSmooth(eigen::DMatXX& data,
+    const std::array<double, 2>& gridSpacing,
+    SmoothGridUnit gridUnit,
+    const std::array<bool, 2>& periodicAxes) const {
+  if (!mClampSmooth.enabled || data.size() == 0) {
+    return;
+  }
+
+  // clamp always acts on the final physical undulation in metres
+  data = data.array().max(mClampSmooth.clampMin).min(mClampSmooth.clampMax);
+
+  // user sigma is in degrees on spherical grids and metres on Cartesian grids;
+  // source-centred spherical coordinates are stored internally in radians
+  double sigmaGridUnit = mClampSmooth.sigmaDegreeOrMeter;
+  if (gridUnit == SmoothGridUnit::RADIAN) {
+    sigmaGridUnit *= numerical::dDegree;
+  }
+
+  // separable Gaussian with model-specific boundary topology
+  for (int axis = 0; axis < 2; axis++) {
+    if (!(gridSpacing[axis] > 0.) || !std::isfinite(gridSpacing[axis])) {
+      throw std::runtime_error("Geometric3D::applyClampSmooth || "
+                               "Invalid spacing on the native model grid. || Model name: " +
+          mModelName);
+    }
+    const double sigmaIndex = sigmaGridUnit / gridSpacing[axis];
+    const int radius = (int)std::round(sGaussianTruncate * sigmaIndex);
+    if (radius == 0) {
+      continue;
+    }
+
+    eigen::DColX kernel(radius * 2 + 1);
+    for (int iker = -radius; iker <= radius; iker++) {
+      kernel(iker + radius) = std::exp(-.5 * iker * iker / (sigmaIndex * sigmaIndex));
+    }
+    kernel /= kernel.sum();
+
+    const int nAxis = axis == 0 ? (int)data.rows() : (int)data.cols();
+    eigen::DMatXX result = eigen::DMatXX::Zero(data.rows(), data.cols());
+    for (int irow = 0; irow < data.rows(); irow++) {
+      for (int icol = 0; icol < data.cols(); icol++) {
+        for (int iker = -radius; iker <= radius; iker++) {
+          int index = (axis == 0 ? irow : icol) + iker;
+          if (periodicAxes[axis]) {
+            index %= nAxis;
+            if (index < 0) {
+              index += nAxis;
+            }
+          } else {
+            index = std::max(0, std::min(index, nAxis - 1));
+          }
+          const int jrow = axis == 0 ? index : irow;
+          const int jcol = axis == 1 ? index : icol;
+          result(irow, icol) += kernel(iker + radius) * data(jrow, jcol);
+        }
+      }
+    }
+    data = result;
+  }
+}
+
+// verbose for clamp and smooth
+std::string
+Geometric3D::verboseClampSmooth(int indent, int width) const {
+  using namespace bstring;
+  std::stringstream ss;
+  ss << boxSubTitle(indent, "Clamp and Gaussian smoothing");
+  ss << boxEquals(indent + 2, width, "enabled", mClampSmooth.enabled);
+  ss << boxEquals(
+      indent + 2, width, "clamp range (m)", range(mClampSmooth.clampMin, mClampSmooth.clampMax));
+  ss << boxEquals(indent + 2, width, "sigma (degree or m)", mClampSmooth.sigmaDegreeOrMeter);
+  return ss.str();
+}
 
 // apply to Quad
 void
@@ -122,6 +252,9 @@ Geometric3D::buildInparam(const ExodusMesh& exodusMesh,
   // class name
   const std::string& className = gm.get<std::string>(root + ":class_name");
 
+  // clamp and Gaussian smoothing shared by geometric models
+  const ClampSmoothConfig& clampSmooth = readClampSmooth(gm, root, modelName, className);
+
   // init class
   if (className == "StructuredGridG3D") {
     // file name
@@ -178,8 +311,15 @@ Geometric3D::buildInparam(const ExodusMesh& exodusMesh,
         angleUnit,
         dataVarName,
         factor,
-        superOnly);
+        superOnly,
+        clampSmooth);
   } else if (className == "Ellipticity") {
+    if (clampSmooth.enabled) {
+      throw std::runtime_error("Geometric3D::buildInparam || "
+                               "clamp_smooth is not supported for the analytical Ellipticity "
+                               "model. || Model name: " +
+          modelName);
+    }
     // ellipticity can be added only once
     static bool ellipticityAdded = false;
     if (ellipticityAdded) {
@@ -207,8 +347,6 @@ Geometric3D::buildInparam(const ExodusMesh& exodusMesh,
     bool ellipticity = gm.get<bool>(root + ":ellipticity");
     double surfaceFactor = gm.get<double>(root + ":surface_factor");
     double mohoFactor = gm.get<double>(root + ":moho_factor");
-    int gaussianOrder = gm.get<int>(root + ":gaussian_order");
-    double gaussianDev = gm.get<double>(root + ":gaussian_deviation");
     return std::make_shared<const Crust1G3D>(modelName,
         rSurf,
         rMoho,
@@ -218,8 +356,7 @@ Geometric3D::buildInparam(const ExodusMesh& exodusMesh,
         ellipticity,
         surfaceFactor,
         mohoFactor,
-        gaussianOrder,
-        gaussianDev);
+        clampSmooth);
   }
 
   // unknown class

--- a/src/models3D/geometric/Geometric3D.hpp
+++ b/src/models3D/geometric/Geometric3D.hpp
@@ -14,10 +14,20 @@
 
 #include "Model3D.hpp"
 
+// configuration for clamping and Gaussian smoothing of geometric models
+struct ClampSmoothConfig {
+  bool enabled = false;
+  double clampMin = -1e10;
+  double clampMax = 1e10;
+  double sigmaDegreeOrMeter = 1.;
+};
+
 class Geometric3D : public Model3D {
   public:
   // constructor
-  Geometric3D(const std::string& modelName) : Model3D(modelName) {
+  Geometric3D(
+      const std::string& modelName, const ClampSmoothConfig& clampSmooth = ClampSmoothConfig()) :
+      Model3D(modelName), mClampSmooth(clampSmooth) {
     // nothing
   }
 
@@ -29,6 +39,20 @@ class Geometric3D : public Model3D {
   applyTo(std::vector<Quad>& quads) const;
 
   protected:
+  // units of the two axes on the model's native horizontal grid
+  enum class SmoothGridUnit { METER, RADIAN, DEGREE };
+
+  // clamp in metres, then smooth on the model's native horizontal grid
+  void
+  applyClampSmooth(eigen::DMatXX& data,
+      const std::array<double, 2>& gridSpacing,
+      SmoothGridUnit gridUnit,
+      const std::array<bool, 2>& periodicAxes = {false, false}) const;
+
+  // verbose for clamp and smooth
+  std::string
+  verboseClampSmooth(int indent, int width) const;
+
   // get undulation on an element
   virtual bool
   getUndulation(
@@ -54,6 +78,10 @@ class Geometric3D : public Model3D {
       const LocalMesh& localMesh,
       const std::string& modelName,
       const std::string& keyInparam);
+
+  protected:
+  // common clamp-and-smooth configuration
+  const ClampSmoothConfig mClampSmooth;
 };
 
 #endif /* Geometric3D_hpp */

--- a/src/models3D/geometric/StructuredGridG3D.cpp
+++ b/src/models3D/geometric/StructuredGridG3D.cpp
@@ -10,6 +10,26 @@
 //  3D geometric models based on structured grid
 
 #include "StructuredGridG3D.hpp"
+#include <cmath>
+
+namespace {
+  double
+  uniformSpacing(
+      const std::vector<double>& coords, const std::string& axis, const std::string& modelName) {
+    const double spacing = (coords.back() - coords.front()) / (coords.size() - 1);
+    const double tolerance = std::max(1., std::abs(spacing)) * 1e-8;
+    for (int index = 1; index < coords.size(); index++) {
+      if (std::abs(coords[index] - coords[index - 1] - spacing) > tolerance) {
+        throw std::runtime_error("StructuredGridG3D::StructuredGridG3D || "
+                                 "Clamp and Gaussian smoothing requires a uniformly spaced "
+                                 "horizontal grid. || Axis: " +
+            axis + " || Model name: " + modelName);
+      }
+    }
+    return spacing;
+  }
+
+} // namespace
 
 // constructor
 StructuredGridG3D::StructuredGridG3D(const std::string& modelName,
@@ -28,15 +48,17 @@ StructuredGridG3D::StructuredGridG3D(const std::string& modelName,
     double angleUnit,
     const std::string& dataVarName,
     double factor,
-    bool superOnly) :
-    Geometric3D(modelName), mFileName(fname), mCrdVarNames(crdVarNames),
+    bool superOnly,
+    const ClampSmoothConfig& clampSmooth) :
+    Geometric3D(modelName, clampSmooth), mFileName(fname), mCrdVarNames(crdVarNames),
     mSourceCentered(sourceCentered), mXY(xy), mEllipticity(ellipticity), mUseDepth(useDepth),
     mDepthSolid(depthSolid), mInterface(interface * lengthUnit), mMin(min * lengthUnit),
     mMax(max * lengthUnit), mDataVarName(dataVarName), mFactor(factor), mSuperOnly(superOnly) {
   ////////////// init grid //////////////
   // info
   std::vector<std::pair<std::string, double>> dataInfo;
-  dataInfo.push_back({mDataVarName, mFactor});
+  // With clamp enabled, materialise the factor before the nonlinear operation.
+  dataInfo.push_back({mDataVarName, mClampSmooth.enabled ? 1. : mFactor});
 
   // lambda
   auto initGrid = [this, &dataInfo, &shuffleData, &lengthUnit, &angleUnit]() {
@@ -48,6 +70,48 @@ StructuredGridG3D::StructuredGridG3D(const std::string& modelName,
     // longitude range
     if (!mSourceCentered) {
       mLon360 = sg_tools::constructLon360(*mGrid, mModelName);
+    }
+
+    // clamp and smooth each unique data field on the native horizontal grid
+    if (mClampSmooth.enabled) {
+      const auto& coords = mGrid->getGridCoords();
+      const std::array<double, 2> spacing = {uniformSpacing(coords[0], mCrdVarNames[0], mModelName),
+          uniformSpacing(coords[1], mCrdVarNames[1], mModelName)};
+
+      SmoothGridUnit gridUnit;
+      if (geodesy::isCartesian()) {
+        if (!mSourceCentered || !mXY) {
+          throw std::runtime_error("StructuredGridG3D::StructuredGridG3D || "
+                                   "Clamp and Gaussian smoothing in Cartesian geometry requires "
+                                   "an XY grid in metres. || Model name: " +
+              mModelName);
+        }
+        gridUnit = SmoothGridUnit::METER;
+      } else if (!mSourceCentered) {
+        // latitude and longitude are stored internally in degrees
+        gridUnit = SmoothGridUnit::DEGREE;
+      } else {
+        // spherical distance and azimuth are stored internally in radians
+        gridUnit = SmoothGridUnit::RADIAN;
+      }
+
+      auto& gridData = mGrid->getGridData();
+      const int n0 = (int)gridData.dimension(1);
+      const int n1 = (int)gridData.dimension(2);
+      for (int idata = 0; idata < mGrid->numUniqueData(); idata++) {
+        eigen::DMatXX physical(n0, n1);
+        for (int i0 = 0; i0 < n0; i0++) {
+          for (int i1 = 0; i1 < n1; i1++) {
+            physical(i0, i1) = gridData(idata, i0, i1) * mFactor;
+          }
+        }
+        applyClampSmooth(physical, spacing, gridUnit);
+        for (int i0 = 0; i0 < n0; i0++) {
+          for (int i1 = 0; i1 < n1; i1++) {
+            gridData(idata, i0, i1) = physical(i0, i1);
+          }
+        }
+      }
     }
   };
 
@@ -180,5 +244,6 @@ StructuredGridG3D::verbose() const {
   const auto& minMax = mGrid->getDataRange();
   ss << boxEquals(4, 19, "data range", range(minMax(0, 0), minMax(0, 1)));
   ss << boxEquals(4, 19, "leader-only storage", mSuperOnly);
+  ss << verboseClampSmooth(2, 19);
   return ss.str();
 }

--- a/src/models3D/geometric/StructuredGridG3D.hpp
+++ b/src/models3D/geometric/StructuredGridG3D.hpp
@@ -34,7 +34,8 @@ class StructuredGridG3D : public Geometric3D {
       double angleUnit,
       const std::string& dataVarName,
       double factor,
-      bool superOnly);
+      bool superOnly,
+      const ClampSmoothConfig& clampSmooth);
 
   private:
   // get undulation on an element

--- a/src/preloop/se_model/SE_Model.cpp
+++ b/src/preloop/se_model/SE_Model.cpp
@@ -47,6 +47,9 @@ SE_Model::SE_Model(const ExodusMesh& exodusMesh,
     const LocalMesh& localMesh,
     const std::vector<std::shared_ptr<const Model3D>>& models3D,
     bool useLuckyNumbers) : mDistToleranceMesh(exodusMesh.getGlobalVariable("dist_tolerance")) {
+  // global acceptance threshold for geometric deformation
+  Undulation::setupMinimumJacobian();
+
   ///////////////// generate empty GLL points /////////////////
   timer::gPreloopTimer.begin("Generating empty points");
   int ngll = (int)(localMesh.mL2G_GLL.rows());

--- a/src/preloop/se_model/quad/physical/Undulation.cpp
+++ b/src/preloop/se_model/quad/physical/Undulation.cpp
@@ -14,8 +14,24 @@
 #include "SolverFFTW.cpp"
 #include "Quad.hpp"
 #include "geodesy.hpp"
+#include "inparam.hpp"
+#include <cmath>
 
 using spectral::nPEM;
+
+// setup minimum acceptable Jacobian from inparam.advanced.yaml
+void
+Undulation::setupMinimumJacobian() {
+  const std::string key = "minimum_jacobian";
+  sMinimumJacobian = .1;
+  if (inparam::gInparamAdvanced.contains(key)) {
+    sMinimumJacobian = inparam::gInparamAdvanced.get<double>(key);
+  }
+  if (!(sMinimumJacobian >= 0.) || !std::isfinite(sMinimumJacobian)) {
+    throw std::runtime_error("Undulation::setupMinimumJacobian || "
+                             "minimum_jacobian must be non-negative and finite.");
+  }
+}
 
 // finishing 3D properties
 void
@@ -111,9 +127,13 @@ Undulation::getMassJacobian(const eigen::DMat2N& sz) const {
       J0 = (Z > numerical::dEpsilon) ? (1. + dZ[ipnt].array() / Z) : J3;
     }
     J[ipnt] = J0.array().square() * J3.array();
-    if (J[ipnt].minCoeff() < numerical::dEpsilon) {
+    const double jacobianMin = J[ipnt].minCoeff();
+    const double threshold = std::max(sMinimumJacobian, numerical::dEpsilon);
+    if (jacobianMin < threshold) {
       throw std::runtime_error("Undulation::getMassJacobian || "
-                               "Negative Jacobian or distorted element occurred.");
+                               "Jacobian is below minimum_jacobian. || "
+                               "Jacobian: " +
+          std::to_string(jacobianMin) + " || Minimum: " + std::to_string(sMinimumJacobian));
     }
   }
   return J;
@@ -149,9 +169,13 @@ Undulation::createPRT(const eigen::DMat2N& sz) const {
   const eigen::DMatXN& X2 = -J2.cwiseQuotient((J0.cwiseProduct(J3)));
   const eigen::DMatXN& X3 = J3.cwiseInverse();
   const eigen::DMatXN& XJ = J0.array().square() * J3.array();
-  if (XJ.minCoeff() < numerical::dEpsilon) {
+  const double jacobianMin = XJ.minCoeff();
+  const double threshold = std::max(sMinimumJacobian, numerical::dEpsilon);
+  if (jacobianMin < threshold) {
     throw std::runtime_error("Undulation::createPRT || "
-                             "Negative Jacobian or distorted element occurred.");
+                             "Jacobian is below minimum_jacobian. || "
+                             "Jacobian: " +
+        std::to_string(jacobianMin) + " || Minimum: " + std::to_string(sMinimumJacobian));
   }
 
   // create PRT

--- a/src/preloop/se_model/quad/physical/Undulation.hpp
+++ b/src/preloop/se_model/quad/physical/Undulation.hpp
@@ -82,6 +82,10 @@ class Undulation {
 
   ///////////////////////// static /////////////////////////
   public:
+  // setup minimum acceptable Jacobian from inparam.advanced.yaml
+  static void
+  setupMinimumJacobian();
+
   // finished 3D properties
   static void
   finished3D();
@@ -92,6 +96,7 @@ class Undulation {
   inline static SolverFFTW<double, spectral::nPEM * 3> sFFT_N3;
   inline static eigen::vec_ar1_ZMatPP_RM sDeltaZ_Fourier;
   inline static eigen::vec_ar3_ZMatPP_RM sDeltaZ_SPZ_Fourier;
+  inline static double sMinimumJacobian = .1;
 };
 
 #endif /* Undulation_hpp */

--- a/src/shared/data_structure/StructuredGrid.hpp
+++ b/src/shared/data_structure/StructuredGrid.hpp
@@ -287,6 +287,12 @@ template <int D, typename T> class StructuredGrid {
     return mGridData;
   }
 
+  // get mutable grid data during model initialization
+  Eigen::Tensor<T, 1 + D, Eigen::RowMajor>&
+  getGridData() {
+    return mGridData;
+  }
+
   // get data range
   eigen::DMatXX
   getDataRange() const {


### PR DESCRIPTION
Adds optional clamping and Gaussian smoothing for geometric undulations, including periodic longitude handling for built-in CRUST1.0.

Also adds a configurable minimum_jacobian check, with a default of 0.1, to stop distorted meshes during preloop.

Examples and documentation are updated. Full build passes. Code formatted